### PR TITLE
feat: redesign map pins as flag chip labels

### DIFF
--- a/__tests__/helpers/leaflet-mock.ts
+++ b/__tests__/helpers/leaflet-mock.ts
@@ -10,6 +10,9 @@ export function createLeafletMock() {
     closePopup: vi.fn().mockReturnThis(),
     remove: vi.fn().mockReturnThis(),
     getTooltip: vi.fn().mockReturnValue(null),
+    setZIndexOffset: vi.fn().mockReturnThis(),
+    getElement: vi.fn().mockReturnValue(null),
+    getLatLng: vi.fn().mockReturnValue({ lat: 0, lng: 0 }),
   };
 
   const mockMap = {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -168,6 +168,7 @@ body {
 }
 .show-poi-labels .pin-marker {
   opacity: 0;
+  pointer-events: none;
 }
 
 /* Dark mode flag chip */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -87,7 +87,8 @@ body {
 .pin-wrapper {
   position: relative;
   display: flex;
-  align-items: flex-end;
+  flex-direction: column;
+  align-items: center;
   pointer-events: none;
 }
 .pin-marker {
@@ -103,22 +104,50 @@ body {
   flex-shrink: 0;
 }
 
-/* Pill label attached to pin — hidden by default, shown at high zoom */
-.pin-label {
+/* Flag label — sits above pin as a unified chip with icon + text */
+.pin-flag {
   position: absolute;
-  left: 30px;
-  bottom: 10px;
-  padding: 2px 8px;
-  border-radius: 10px;
-  font-size: 11px;
-  font-weight: 600;
-  color: white;
+  bottom: 34px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 0;
+  background: white;
+  border-radius: 12px;
+  padding: 2px 3px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.22);
   white-space: nowrap;
   opacity: 0;
   transition: opacity 0.3s ease;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
   pointer-events: none;
 }
-.show-poi-labels .pin-label {
-  opacity: 0.92;
+.pin-flag::after {
+  content: "";
+  position: absolute;
+  bottom: -5px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 5px solid white;
+}
+.pin-flag-dot {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.pin-flag-text {
+  padding: 0 6px 0 4px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #1a1a1a;
+  line-height: 1;
+}
+.show-poi-labels .pin-flag {
+  opacity: 1;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -119,6 +119,7 @@ body {
   box-shadow: 0 1px 6px rgba(0, 0, 0, 0.28);
   white-space: nowrap;
   cursor: pointer;
+  transition: box-shadow 0.2s ease;
 }
 .pin-flag::after {
   content: "";
@@ -145,6 +146,20 @@ body {
   font-weight: 600;
   color: #1a1a1a;
   line-height: 1;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: max-width 0.3s ease;
+}
+
+/* Expand name on hover or when active (selected) */
+.pin-flag:hover .pin-flag-text,
+.pin-wrapper.active .pin-flag-text {
+  max-width: 300px;
+}
+.pin-flag:hover,
+.pin-wrapper.active .pin-flag {
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.35);
 }
 
 /* At high zoom: show flag, hide pin */
@@ -153,4 +168,25 @@ body {
 }
 .show-poi-labels .pin-marker {
   opacity: 0;
+}
+
+/* Dark mode flag chip */
+@media (prefers-color-scheme: dark) {
+  .pin-flag {
+    background: #1e293b;
+    box-shadow: 0 1px 6px rgba(0, 0, 0, 0.5);
+  }
+  .pin-flag::after {
+    border-top-color: #1e293b;
+  }
+  .pin-flag-text {
+    color: #e2e8f0;
+  }
+  .pin-flag:hover,
+  .pin-wrapper.active .pin-flag {
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.6);
+  }
+  .pin-marker {
+    border-color: #334155;
+  }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -102,39 +102,40 @@ body {
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
+  transition: opacity 0.2s ease;
 }
 
-/* Flag label — sits above pin as a unified chip with icon + text */
+/* Flag chip — replaces the pin at high zoom */
 .pin-flag {
   position: absolute;
-  bottom: 34px;
+  bottom: 6px;
   left: 50%;
   transform: translateX(-50%);
   display: flex;
   align-items: center;
   gap: 0;
   background: white;
-  border-radius: 12px;
-  padding: 2px 3px;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.22);
+  border-radius: 14px;
+  padding: 3px 4px;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.28);
   white-space: nowrap;
   opacity: 0;
-  transition: opacity 0.3s ease;
   pointer-events: none;
+  transition: opacity 0.2s ease;
 }
 .pin-flag::after {
   content: "";
   position: absolute;
-  bottom: -5px;
+  bottom: -6px;
   left: 50%;
   transform: translateX(-50%);
-  border-left: 5px solid transparent;
-  border-right: 5px solid transparent;
-  border-top: 5px solid white;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-top: 6px solid white;
 }
 .pin-flag-dot {
-  width: 18px;
-  height: 18px;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
   display: flex;
   align-items: center;
@@ -142,12 +143,17 @@ body {
   flex-shrink: 0;
 }
 .pin-flag-text {
-  padding: 0 6px 0 4px;
-  font-size: 11px;
+  padding: 0 8px 0 5px;
+  font-size: 11.5px;
   font-weight: 600;
   color: #1a1a1a;
   line-height: 1;
 }
+
+/* At high zoom: show flag, hide pin */
 .show-poi-labels .pin-flag {
   opacity: 1;
+}
+.show-poi-labels .pin-marker {
+  opacity: 0;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -83,32 +83,42 @@ body {
   font-size: 13px;
 }
 
-/* POI permanent labels shown at high zoom */
-.poi-label {
-  background: rgba(255, 255, 255, 0.85);
-  backdrop-filter: blur(4px);
-  border: none;
-  border-radius: 4px;
-  padding: 2px 6px;
-  font-size: 12px;
-  font-weight: 500;
-  color: #1e293b;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
-  white-space: nowrap;
+/* Pin marker — teardrop shape with icon */
+.pin-wrapper {
+  position: relative;
+  display: flex;
+  align-items: flex-end;
   pointer-events: none;
-  opacity: 0 !important;
+}
+.pin-marker {
+  width: 32px;
+  height: 32px;
+  border: 2px solid white;
+  border-radius: 50% 50% 50% 0;
+  transform: rotate(-45deg);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+/* Pill label attached to pin — hidden by default, shown at high zoom */
+.pin-label {
+  position: absolute;
+  left: 30px;
+  bottom: 10px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  color: white;
+  white-space: nowrap;
+  opacity: 0;
   transition: opacity 0.3s ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+  pointer-events: none;
 }
-@media (prefers-color-scheme: dark) {
-  .poi-label {
-    background: rgba(30, 41, 59, 0.9);
-    color: #e2e8f0;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
-  }
-}
-.show-poi-labels .poi-label {
-  opacity: 0.9 !important;
-}
-.poi-label::before {
-  display: none;
+.show-poi-labels .pin-label {
+  opacity: 0.92;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -89,7 +89,6 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  pointer-events: none;
 }
 .pin-marker {
   width: 32px;
@@ -105,13 +104,13 @@ body {
   transition: opacity 0.2s ease;
 }
 
-/* Flag chip — replaces the pin at high zoom */
+/* Flag chip — hidden by default, replaces pin at high zoom */
 .pin-flag {
   position: absolute;
   bottom: 6px;
   left: 50%;
   transform: translateX(-50%);
-  display: flex;
+  display: none;
   align-items: center;
   gap: 0;
   background: white;
@@ -119,9 +118,7 @@ body {
   padding: 3px 4px;
   box-shadow: 0 1px 6px rgba(0, 0, 0, 0.28);
   white-space: nowrap;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.2s ease;
+  cursor: pointer;
 }
 .pin-flag::after {
   content: "";
@@ -152,7 +149,7 @@ body {
 
 /* At high zoom: show flag, hide pin */
 .show-poi-labels .pin-flag {
-  opacity: 1;
+  display: flex;
 }
 .show-poi-labels .pin-marker {
   opacity: 0;

--- a/src/components/LocationMap.tsx
+++ b/src/components/LocationMap.tsx
@@ -69,18 +69,15 @@ const PIN_ICONS: Record<PlaceType, string> = {
   museum: `<path d="M10 18v-7"/><path d="M11.12 2.198a2 2 0 0 1 1.76.006l7.866 3.847c.476.233.31.949-.22.949H3.474c-.53 0-.695-.716-.22-.949z"/><path d="M14 18v-7"/><path d="M18 18v-7"/><path d="M3 22h18"/><path d="M6 18v-7"/>`,
 };
 
-function createPinIcon(type: PlaceType, opacity = 1, name?: string): L.DivIcon {
+function createPinIcon(type: PlaceType, opacity = 1, name?: string, slug?: string): L.DivIcon {
   const color = PIN_COLORS[type];
   const svgPaths = PIN_ICONS[type];
-  const displayName = name
-    ? name.length > 20 ? name.slice(0, 18) + "…" : name
-    : "";
   const labelHtml = name
-    ? `<div class="pin-flag"><div class="pin-flag-dot" style="background:${color};"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">${svgPaths}</svg></div><span class="pin-flag-text">${displayName}</span></div>`
+    ? `<div class="pin-flag"><div class="pin-flag-dot" style="background:${color};"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">${svgPaths}</svg></div><span class="pin-flag-text">${name}</span></div>`
     : "";
   return L.divIcon({
     className: "",
-    html: `<div class="pin-wrapper" style="opacity:${opacity};"><div class="pin-marker" style="background:${color};"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="transform:rotate(45deg);">${svgPaths}</svg></div>${labelHtml}</div>`,
+    html: `<div class="pin-wrapper" data-slug="${slug ?? ""}" style="opacity:${opacity};"><div class="pin-marker" style="background:${color};"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="transform:rotate(45deg);">${svgPaths}</svg></div>${labelHtml}</div>`,
     iconSize: [32, 32],
     iconAnchor: [16, 32],
     popupAnchor: [0, -32],
@@ -323,7 +320,7 @@ export default function LocationMap({
       }
 
       const marker = L.marker([loc.coordinates.lat, loc.coordinates.lng], {
-        icon: createPinIcon(loc.type, pinOpacity, loc.name),
+        icon: createPinIcon(loc.type, pinOpacity, loc.name, loc.slug),
       });
 
       if (clusterGroup) clusterGroup.addLayer(marker);
@@ -341,9 +338,14 @@ export default function LocationMap({
       // Hover behaviour (desktop only — touch devices fire spurious
       // mouseover/mouseout that would immediately close the popup)
       marker.on("mouseover", () => {
+        marker.setZIndexOffset(10000);
         onMarkerHover(loc.slug);
       });
       marker.on("mouseout", () => {
+        // Keep elevated z-index if this is the focused marker
+        if (loc.slug !== prevFocusedSlugRef.current) {
+          marker.setZIndexOffset(0);
+        }
         onMarkerHover(null);
       });
 
@@ -399,7 +401,18 @@ export default function LocationMap({
   // location is active.
   useEffect(() => {
     const slugChanged = focusedSlug !== prevFocusedSlugRef.current;
+    const prevSlug = prevFocusedSlugRef.current;
     prevFocusedSlugRef.current = focusedSlug;
+
+    // Remove active state from previous marker
+    if (prevSlug && slugChanged) {
+      const prevMarker = markersRef.current.get(prevSlug);
+      if (prevMarker) {
+        prevMarker.setZIndexOffset(0);
+        const el = prevMarker.getElement();
+        el?.querySelector(".pin-wrapper")?.classList.remove("active");
+      }
+    }
 
     if (!focusedSlug) {
       // Clear route when detail panel closes
@@ -415,6 +428,11 @@ export default function LocationMap({
     const map = mapRef.current;
     const marker = markersRef.current.get(focusedSlug);
     if (map && marker) {
+      // Elevate and mark as active
+      marker.setZIndexOffset(10000);
+      const el = marker.getElement();
+      el?.querySelector(".pin-wrapper")?.classList.add("active");
+
       const sh = focusSheetHeight ?? getSheetHeight();
       setViewAboveSheet(map, marker.getLatLng(), 15, sh);
 

--- a/src/components/LocationMap.tsx
+++ b/src/components/LocationMap.tsx
@@ -72,8 +72,11 @@ const PIN_ICONS: Record<PlaceType, string> = {
 function createPinIcon(type: PlaceType, opacity = 1, name?: string): L.DivIcon {
   const color = PIN_COLORS[type];
   const svgPaths = PIN_ICONS[type];
+  const displayName = name
+    ? name.length > 20 ? name.slice(0, 18) + "…" : name
+    : "";
   const labelHtml = name
-    ? `<span class="pin-label" style="background:${color};">${name.length > 20 ? name.slice(0, 18) + "…" : name}</span>`
+    ? `<div class="pin-flag" style="opacity:${opacity};"><div class="pin-flag-dot" style="background:${color};"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">${svgPaths}</svg></div><span class="pin-flag-text">${displayName}</span></div>`
     : "";
   return L.divIcon({
     className: "",

--- a/src/components/LocationMap.tsx
+++ b/src/components/LocationMap.tsx
@@ -156,6 +156,7 @@ export default function LocationMap({
 
   const [locating, setLocating] = useState(false);
   const [locateError, setLocateError] = useState<string | null>(null);
+  const prevFocusedSlugRef = useRef<string | null | undefined>(null);
 
   // Initialize map
   useEffect(() => {
@@ -392,8 +393,14 @@ export default function LocationMap({
   }, [highlightedSlug, focusedSlug, locations]);
 
   // Focus effect — zoom to pin and center in visible area above sheet,
-  // and draw route polyline for walk/bushwalk types
+  // and draw route polyline for walk/bushwalk types.
+  // Only fly to the POI when focusedSlug changes (not on sheet resize),
+  // so the user can navigate freely (e.g. locate themselves) while a
+  // location is active.
   useEffect(() => {
+    const slugChanged = focusedSlug !== prevFocusedSlugRef.current;
+    prevFocusedSlugRef.current = focusedSlug;
+
     if (!focusedSlug) {
       // Clear route when detail panel closes
       if (routeLayerRef.current) {
@@ -402,6 +409,9 @@ export default function LocationMap({
       }
       return;
     }
+
+    if (!slugChanged) return;
+
     const map = mapRef.current;
     const marker = markersRef.current.get(focusedSlug);
     if (map && marker) {

--- a/src/components/LocationMap.tsx
+++ b/src/components/LocationMap.tsx
@@ -76,7 +76,7 @@ function createPinIcon(type: PlaceType, opacity = 1, name?: string): L.DivIcon {
     ? name.length > 20 ? name.slice(0, 18) + "…" : name
     : "";
   const labelHtml = name
-    ? `<div class="pin-flag" style="opacity:${opacity};"><div class="pin-flag-dot" style="background:${color};"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">${svgPaths}</svg></div><span class="pin-flag-text">${displayName}</span></div>`
+    ? `<div class="pin-flag"><div class="pin-flag-dot" style="background:${color};"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">${svgPaths}</svg></div><span class="pin-flag-text">${displayName}</span></div>`
     : "";
   return L.divIcon({
     className: "",

--- a/src/components/LocationMap.tsx
+++ b/src/components/LocationMap.tsx
@@ -69,24 +69,15 @@ const PIN_ICONS: Record<PlaceType, string> = {
   museum: `<path d="M10 18v-7"/><path d="M11.12 2.198a2 2 0 0 1 1.76.006l7.866 3.847c.476.233.31.949-.22.949H3.474c-.53 0-.695-.716-.22-.949z"/><path d="M14 18v-7"/><path d="M18 18v-7"/><path d="M3 22h18"/><path d="M6 18v-7"/>`,
 };
 
-function createPinIcon(type: PlaceType, opacity = 1): L.DivIcon {
+function createPinIcon(type: PlaceType, opacity = 1, name?: string): L.DivIcon {
   const color = PIN_COLORS[type];
   const svgPaths = PIN_ICONS[type];
+  const labelHtml = name
+    ? `<span class="pin-label" style="background:${color};">${name.length > 20 ? name.slice(0, 18) + "…" : name}</span>`
+    : "";
   return L.divIcon({
     className: "",
-    html: `<div style="
-      width: 32px; height: 32px;
-      background: ${color};
-      border: 2px solid white;
-      border-radius: 50% 50% 50% 0;
-      transform: rotate(-45deg);
-      box-shadow: 0 2px 4px rgba(0,0,0,0.3);
-      pointer-events: none;
-      opacity: ${opacity};
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    "><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="transform: rotate(45deg);">${svgPaths}</svg></div>`,
+    html: `<div class="pin-wrapper" style="opacity:${opacity};"><div class="pin-marker" style="background:${color};"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="transform:rotate(45deg);">${svgPaths}</svg></div>${labelHtml}</div>`,
     iconSize: [32, 32],
     iconAnchor: [16, 32],
     popupAnchor: [0, -32],
@@ -336,16 +327,8 @@ export default function LocationMap({
       popupContent.append(strong, document.createElement("br"), typeSpan);
 
       const marker = L.marker([loc.coordinates.lat, loc.coordinates.lng], {
-        icon: createPinIcon(loc.type, pinOpacity),
+        icon: createPinIcon(loc.type, pinOpacity, loc.name),
       }).bindPopup(popupContent, { autoClose: true, closeOnClick: true });
-
-      // Permanent label visible at higher zoom levels (CSS-controlled)
-      marker.bindTooltip(loc.name, {
-        permanent: true,
-        direction: "top",
-        offset: L.point(0, -30),
-        className: "poi-label",
-      });
 
       if (clusterGroup) clusterGroup.addLayer(marker);
 

--- a/src/components/LocationMap.tsx
+++ b/src/components/LocationMap.tsx
@@ -352,6 +352,16 @@ export default function LocationMap({
       markersRef.current.set(loc.slug, marker);
     }
 
+    // Re-apply active state if a marker is currently focused
+    if (prevFocusedSlugRef.current) {
+      const focusedMarker = markersRef.current.get(prevFocusedSlugRef.current);
+      if (focusedMarker) {
+        focusedMarker.setZIndexOffset(10000);
+        const el = focusedMarker.getElement();
+        el?.querySelector(".pin-wrapper")?.classList.add("active");
+      }
+    }
+
     // Fit bounds only on initial load — subsequent filter/preference changes
     // should not override the user's current viewport
     if (locations.length > 0 && !hasFitBoundsRef.current) {

--- a/src/components/LocationMap.tsx
+++ b/src/components/LocationMap.tsx
@@ -321,23 +321,14 @@ export default function LocationMap({
         pinOpacity = 0.35 + 0.65 * ((s - minScore) / scoreRange);
       }
 
-      const popupContent = document.createElement("div");
-      const strong = document.createElement("strong");
-      strong.textContent = loc.name;
-      const typeSpan = document.createElement("span");
-      typeSpan.style.textTransform = "capitalize";
-      typeSpan.textContent = loc.type.replace("-", " ");
-      popupContent.append(strong, document.createElement("br"), typeSpan);
-
       const marker = L.marker([loc.coordinates.lat, loc.coordinates.lng], {
         icon: createPinIcon(loc.type, pinOpacity, loc.name),
-      }).bindPopup(popupContent, { autoClose: true, closeOnClick: true });
+      });
 
       if (clusterGroup) clusterGroup.addLayer(marker);
 
-      // On click: open popup, notify parent (route drawn by focus effect)
+      // On click: notify parent (route drawn by focus effect)
       marker.on("click", () => {
-        marker.openPopup();
         // Clear any hover route
         if (hoverRouteLayerRef.current) {
           hoverRouteLayerRef.current.remove();
@@ -349,11 +340,9 @@ export default function LocationMap({
       // Hover behaviour (desktop only — touch devices fire spurious
       // mouseover/mouseout that would immediately close the popup)
       marker.on("mouseover", () => {
-        if (window.matchMedia("(hover: hover)").matches) marker.openPopup();
         onMarkerHover(loc.slug);
       });
       marker.on("mouseout", () => {
-        if (window.matchMedia("(hover: hover)").matches) marker.closePopup();
         onMarkerHover(null);
       });
 
@@ -376,14 +365,10 @@ export default function LocationMap({
     }
   }, [locations, onMarkerClick, onMarkerHover]);
 
-  // Highlight effect — open popup on hover, draw route polyline for walks
+  // Highlight effect — draw route polyline for walks on hover
   useEffect(() => {
     if (!highlightedSlug) return;
     const map = mapRef.current;
-    const marker = markersRef.current.get(highlightedSlug);
-    if (marker) {
-      marker.openPopup();
-    }
 
     // Draw route polyline for walk/bushwalk types (desktop hover only)
     // Skip if the focused detail panel already shows this route
@@ -399,7 +384,6 @@ export default function LocationMap({
     }
 
     return () => {
-      mapRef.current?.closePopup();
       if (hoverRouteLayerRef.current) {
         hoverRouteLayerRef.current.remove();
         hoverRouteLayerRef.current = null;


### PR DESCRIPTION
## Summary

Redesigns map pin labels as integrated "flag chips" that replace the teardrop pin at high zoom levels, inspired by Google Maps POI labels.

## Changes

### Flag chip design
- At zoom ≥ 12, teardrop pins fade out and are replaced by flag chips showing a colored category icon dot + POI name
- At zoom < 12, standard teardrop pins are shown (no labels)
- Chips have a speech-bubble arrow pointing down to the exact location

### Interactions
- **Hover**: chip expands to show full name (truncated at 120px by default), rises above overlapping chips via z-index
- **Selection**: active chip stays expanded and elevated until deselected
- **Click target**: entire flag chip area is clickable, not just the center
- Removed redundant hover popup balloons (chip already shows the name)

### Bug fixes
- Fixed locate button not working when a location is active (focus effect was re-firing on sheet resize, overriding map position)
- Fixed hidden pin marker intercepting clicks at high zoom (added pointer-events: none)
- Re-apply active state when markers are recreated after location list changes

### Dark mode
- Flag chips use slate background, light text, and darker shadows in dark mode

### Other
- Updated leaflet test mocks with setZIndexOffset/getElement/getLatLng

## Testing
- All 132 tests pass
- Build succeeds
- Vercel preview deployment verified
- No merge conflicts with main

## Commits
- `0e928e0` feat: integrate POI name as pill label attached to map pin
- `ad4a214` Redesign pin labels as flag chips above markers
- `1cd1b6d` Flag chip replaces pin at high zoom, remove hover popups
- `b0b21f5` Fix flag chip: hide at low zoom, make fully clickable
- `59b5d61` Fix locate button when location is active
- `3b882ed` Flag chip: expand on hover, z-index on focus, dark mode
- `a18ab70` Fix hidden pin intercepting clicks, re-apply active state on marker recreation