### PR TITLE
feat: display opening hours in UI

### DIFF
--- a/__tests__/lib/openingHours.test.ts
+++ b/__tests__/lib/openingHours.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isOpenOnDay, isOpenAt, formatHoursStatus, entriesForDay } from "@/lib/openingHours";
+import { isOpenOnDay, isOpenAt, formatHoursStatus, entriesForDay, todayIdx } from "@/lib/openingHours";
 import type { OpeningHoursEntry } from "@/lib/types";
 
 const weekdays: OpeningHoursEntry = {
@@ -75,5 +75,32 @@ describe("openingHours", () => {
   it("entriesForDay filters correctly", () => {
     expect(entriesForDay([weekdays, fridayNight], "fri")).toHaveLength(2);
     expect(entriesForDay([weekdays, fridayNight], "sun")).toHaveLength(0);
+  });
+
+  it("isOpenAt inside the gap before an overnight range opens", () => {
+    const d = new Date(2026, 3, 17, 19, 0); // Fri 19:00, before 20:00 open
+    expect(isOpenAt([fridayNight], d)).toBe(false);
+  });
+
+  it("isOpenAt between the close and next open of an overnight schedule", () => {
+    const d = new Date(2026, 3, 18, 10, 0); // Sat 10:00 — Fri night closed at 02:00, Sat night opens 20:00
+    expect(isOpenAt([fridayNight], d)).toBe(false);
+  });
+
+  it("isOpenAt with multiple ranges on the same day — lunch split", () => {
+    const split: OpeningHoursEntry[] = [
+      { days: ["wed"], open: "11:00", close: "14:00" },
+      { days: ["wed"], open: "17:00", close: "21:00" },
+    ];
+    expect(isOpenAt(split, new Date(2026, 3, 15, 12, 0))).toBe(true);   // lunch
+    expect(isOpenAt(split, new Date(2026, 3, 15, 15, 0))).toBe(false);  // gap
+    expect(isOpenAt(split, new Date(2026, 3, 15, 19, 0))).toBe(true);   // dinner
+    expect(isOpenAt(split, new Date(2026, 3, 15, 22, 0))).toBe(false);  // closed
+  });
+
+  it("todayIdx returns Monday-origin index", () => {
+    expect(todayIdx(new Date(2026, 3, 13))).toBe(0); // Monday
+    expect(todayIdx(new Date(2026, 3, 15))).toBe(2); // Wednesday
+    expect(todayIdx(new Date(2026, 3, 19))).toBe(6); // Sunday
   });
 });

--- a/__tests__/lib/openingHours.test.ts
+++ b/__tests__/lib/openingHours.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { isOpenOnDay, isOpenAt, formatHoursStatus, entriesForDay } from "@/lib/openingHours";
+import type { OpeningHoursEntry } from "@/lib/types";
+
+const weekdays: OpeningHoursEntry = {
+  days: ["mon", "tue", "wed", "thu", "fri"],
+  open: "09:00",
+  close: "17:00",
+};
+
+const fridayNight: OpeningHoursEntry = {
+  days: ["fri", "sat"],
+  open: "20:00",
+  close: "02:00", // overnight
+};
+
+describe("openingHours", () => {
+  it("isOpenOnDay respects day membership", () => {
+    expect(isOpenOnDay([weekdays], "mon")).toBe(true);
+    expect(isOpenOnDay([weekdays], "sat")).toBe(false);
+    expect(isOpenOnDay([weekdays, fridayNight], "sat")).toBe(true);
+  });
+
+  it("isOpenAt within a simple range", () => {
+    // Wed 2026-04-15 at 12:00
+    const d = new Date(2026, 3, 15, 12, 0);
+    expect(isOpenAt([weekdays], d)).toBe(true);
+  });
+
+  it("isOpenAt outside range", () => {
+    const d = new Date(2026, 3, 15, 8, 0); // Wed 08:00
+    expect(isOpenAt([weekdays], d)).toBe(false);
+  });
+
+  it("isOpenAt closed on non-listed day", () => {
+    const d = new Date(2026, 3, 18, 12, 0); // Saturday
+    expect(isOpenAt([weekdays], d)).toBe(false);
+  });
+
+  it("isOpenAt handles overnight ranges — late evening of start day", () => {
+    const d = new Date(2026, 3, 17, 22, 0); // Fri 22:00
+    expect(isOpenAt([fridayNight], d)).toBe(true);
+  });
+
+  it("isOpenAt handles overnight ranges — early morning of next day", () => {
+    const d = new Date(2026, 3, 18, 1, 0); // Sat 01:00 — carried over from Fri
+    expect(isOpenAt([fridayNight], d)).toBe(true);
+  });
+
+  it("isOpenAt overnight closed at 03:00", () => {
+    const d = new Date(2026, 3, 18, 3, 0);
+    expect(isOpenAt([fridayNight], d)).toBe(false);
+  });
+
+  it("isOpenAt exclusive at close time", () => {
+    const d = new Date(2026, 3, 15, 17, 0);
+    expect(isOpenAt([weekdays], d)).toBe(false);
+  });
+
+  it("isOpenAt inclusive at open time", () => {
+    const d = new Date(2026, 3, 15, 9, 0);
+    expect(isOpenAt([weekdays], d)).toBe(true);
+  });
+
+  it("formatHoursStatus returns null for undefined/empty", () => {
+    expect(formatHoursStatus(undefined)).toBeNull();
+    expect(formatHoursStatus([])).toBeNull();
+  });
+
+  it("formatHoursStatus returns status when entries present", () => {
+    const d = new Date(2026, 3, 15, 12, 0);
+    expect(formatHoursStatus([weekdays], d)).toEqual({ open: true, label: "Open now" });
+  });
+
+  it("entriesForDay filters correctly", () => {
+    expect(entriesForDay([weekdays, fridayNight], "fri")).toHaveLength(2);
+    expect(entriesForDay([weekdays, fridayNight], "sun")).toHaveLength(0);
+  });
+});

--- a/__tests__/scripts/validate-locations.test.ts
+++ b/__tests__/scripts/validate-locations.test.ts
@@ -313,5 +313,13 @@ describe("validatePlace", () => {
       };
       expect(validatePlace(bad)).toContainEqual(expect.stringContaining("days"));
     });
+
+    it("rejects equal open and close", () => {
+      const bad = {
+        ...validSwim,
+        openingHours: [{ days: ["mon"], open: "09:00", close: "09:00" }],
+      };
+      expect(validatePlace(bad)).toContainEqual(expect.stringContaining("must differ"));
+    });
   });
 });

--- a/data/locations/museum/melbourne-holocaust-museum.yaml
+++ b/data/locations/museum/melbourne-holocaust-museum.yaml
@@ -58,6 +58,16 @@ tags:
 status:
   site: open
   lastVerified: "2026-04-13"
+openingHours:
+  - days: [mon, tue, wed, thu]
+    open: "10:00"
+    close: "16:00"
+  - days: [fri]
+    open: "10:00"
+    close: "14:00"
+  - days: [sun]
+    open: "10:00"
+    close: "16:00"
 details: {}
 fit:
   cost: 'Moderately priced and worth every dollar.'

--- a/data/locations/museum/melbourne-holocaust-museum.yaml
+++ b/data/locations/museum/melbourne-holocaust-museum.yaml
@@ -59,13 +59,7 @@ status:
   site: open
   lastVerified: "2026-04-13"
 openingHours:
-  - days: [mon, tue, wed, thu]
-    open: "10:00"
-    close: "16:00"
-  - days: [fri]
-    open: "10:00"
-    close: "14:00"
-  - days: [sun]
+  - days: [tue, wed, thu, fri, sun]
     open: "10:00"
     close: "16:00"
 details: {}

--- a/data/locations/museum/rippon-lea-estate.yaml
+++ b/data/locations/museum/rippon-lea-estate.yaml
@@ -59,7 +59,7 @@ status:
   site: open
   lastVerified: "2026-04-13"
 openingHours:
-  - days: [wed, thu, fri, sat, sun]
+  - days: [mon, tue, wed, thu, fri, sat, sun]
     open: "10:00"
     close: "17:00"
 details: {}

--- a/data/locations/museum/rippon-lea-estate.yaml
+++ b/data/locations/museum/rippon-lea-estate.yaml
@@ -58,6 +58,10 @@ tags:
 status:
   site: open
   lastVerified: "2026-04-13"
+openingHours:
+  - days: [wed, thu, fri, sat, sun]
+    open: "10:00"
+    close: "17:00"
 details: {}
 fit:
   cost: 'Moderately priced and worth every dollar.'

--- a/schemas/location.schema.json
+++ b/schemas/location.schema.json
@@ -257,6 +257,7 @@
       "minItems": 1,
       "items": {
         "type": "object",
+        "description": "open and close must differ. When close <= open the range is treated as overnight (close is on the following day). For all-day use 00:00 / 23:59.",
         "required": [
           "days",
           "open",

--- a/scripts/build-locations.ts
+++ b/scripts/build-locations.ts
@@ -24,6 +24,7 @@ export function buildIndex(places: Place[]): PlaceIndexEntry[] {
       : {}),
     ...(p.fit ? { fit: p.fit } : {}),
     ...(p.source ? { source: p.source } : {}),
+    ...(p.openingHours && p.openingHours.length > 0 ? { openingHours: p.openingHours } : {}),
   }));
 }
 

--- a/scripts/build-schema.ts
+++ b/scripts/build-schema.ts
@@ -69,6 +69,8 @@ const fit = {
 
 const openingHoursEntry = {
   type: "object",
+  description:
+    "open and close must differ. When close <= open the range is treated as overnight (close is on the following day). For all-day use 00:00 / 23:59.",
   required: ["days", "open", "close"],
   additionalProperties: false,
   properties: {

--- a/scripts/validate-locations.ts
+++ b/scripts/validate-locations.ts
@@ -55,11 +55,16 @@ function validateOpeningHours(value: unknown): string[] {
         }
       }
     }
-    if (typeof e.open !== "string" || !TIME_PATTERN.test(e.open)) {
+    const openValid = typeof e.open === "string" && TIME_PATTERN.test(e.open);
+    const closeValid = typeof e.close === "string" && TIME_PATTERN.test(e.close);
+    if (!openValid) {
       errors.push(`${prefix}.open: must be "HH:MM" 24-hour time`);
     }
-    if (typeof e.close !== "string" || !TIME_PATTERN.test(e.close)) {
+    if (!closeValid) {
       errors.push(`${prefix}.close: must be "HH:MM" 24-hour time`);
+    }
+    if (openValid && closeValid && e.open === e.close) {
+      errors.push(`${prefix}: open and close must differ (use 00:00 / 23:59 for all-day)`);
     }
   });
   return errors;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -129,6 +129,7 @@ body {
 }
 .pin-flag-hours {
   display: flex;
+  justify-content: center;
   gap: 2px;
   padding: 0 4px;
   max-height: 0;
@@ -144,8 +145,7 @@ body {
   padding-bottom: 2px;
 }
 .pin-flag-day {
-  flex: 1;
-  min-width: 12px;
+  width: 14px;
   text-align: center;
   font-size: 9px;
   font-weight: 600;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -111,7 +111,8 @@ body {
   left: 50%;
   transform: translateX(-50%);
   display: none;
-  align-items: center;
+  flex-direction: column;
+  align-items: stretch;
   gap: 0;
   background: white;
   border-radius: 14px;
@@ -120,6 +121,45 @@ body {
   white-space: nowrap;
   cursor: pointer;
   transition: box-shadow 0.2s ease;
+}
+.pin-flag-row {
+  display: flex;
+  align-items: center;
+  gap: 0;
+}
+.pin-flag-hours {
+  display: flex;
+  gap: 2px;
+  padding: 0 4px;
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition: max-height 0.2s ease, opacity 0.2s ease, margin-top 0.2s ease;
+}
+.pin-flag:hover .pin-flag-hours,
+.pin-wrapper.active .pin-flag-hours {
+  max-height: 18px;
+  opacity: 1;
+  margin-top: 3px;
+  padding-bottom: 2px;
+}
+.pin-flag-day {
+  flex: 1;
+  min-width: 12px;
+  text-align: center;
+  font-size: 9px;
+  font-weight: 600;
+  line-height: 14px;
+  color: #9ca3af;
+  background: #f3f4f6;
+  border-radius: 3px;
+}
+.pin-flag-day.open {
+  color: white;
+}
+.pin-flag-day.today {
+  outline: 1.5px solid #1a1a1a;
+  outline-offset: 1px;
 }
 .pin-flag::after {
   content: "";
@@ -189,5 +229,15 @@ body {
   }
   .pin-marker {
     border-color: #334155;
+  }
+  .pin-flag-day {
+    color: #64748b;
+    background: #0f172a;
+  }
+  .pin-flag-day.open {
+    color: white;
+  }
+  .pin-flag-day.today {
+    outline-color: #e2e8f0;
   }
 }

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -7,6 +7,7 @@ import StatusBadge from "./StatusBadge";
 import CostIndicator from "./CostIndicator";
 import SourceAttribution from "./SourceAttribution";
 import Image from "next/image";
+import { formatHoursStatus } from "@/lib/openingHours";
 
 interface LocationCardProps {
   location: PlaceIndexEntry & { _driveMinutes?: number | null };
@@ -41,6 +42,7 @@ export default function LocationCard({
   const photo = location.photo && !location.photo.includes("placeholder") ? location.photo : undefined;
 
   const fitBlurb = buildFitParagraph(location.fit, activeConstraints ?? null);
+  const hoursStatus = formatHoursStatus(location.openingHours);
 
   const cardClassName = `block rounded-lg border overflow-hidden transition-all duration-100 active:scale-[0.98] active:shadow-none ${
     isHighlighted
@@ -84,6 +86,17 @@ export default function LocationCard({
             <span className="text-xs text-gray-500 dark:text-gray-400 font-medium">{distance}</span>
           )}
           <CostIndicator cost={location.cost} />
+          {hoursStatus && (
+            <span
+              className={`text-xs font-medium px-1.5 py-0.5 rounded ${
+                hoursStatus.open
+                  ? "bg-emerald-50 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-300"
+                  : "bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400"
+              }`}
+            >
+              {hoursStatus.label}
+            </span>
+          )}
           {location.source && <SourceAttribution source={location.source} />}
         </div>
         {fitBlurb ? (

--- a/src/components/LocationDetailPanel.tsx
+++ b/src/components/LocationDetailPanel.tsx
@@ -32,6 +32,53 @@ const DURATION_DISPLAY: Record<Duration, string> = {
 
 import CostIndicator from "./CostIndicator";
 import SourceAttribution from "./SourceAttribution";
+import { DAYS, DAY_LABELS, entriesForDay, formatHoursStatus } from "@/lib/openingHours";
+import type { OpeningHoursEntry } from "@/lib/types";
+
+function OpeningHoursSection({ entries }: { entries: OpeningHoursEntry[] }) {
+  const todayIdx = (new Date().getDay() + 6) % 7;
+  const status = formatHoursStatus(entries);
+  return (
+    <section className="mb-4">
+      <div className="flex items-center gap-2 mb-2">
+        <Clock className="w-4 h-4 text-gray-400 dark:text-gray-500 shrink-0" />
+        <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100">Hours</h3>
+        {status && (
+          <span
+            className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+              status.open
+                ? "bg-emerald-50 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-300"
+                : "bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400"
+            }`}
+          >
+            {status.label}
+          </span>
+        )}
+      </div>
+      <ul className="text-sm">
+        {DAYS.map((d, i) => {
+          const ranges = entriesForDay(entries, d);
+          const isToday = i === todayIdx;
+          return (
+            <li
+              key={d}
+              className={`flex justify-between py-0.5 ${
+                isToday ? "font-semibold text-gray-900 dark:text-gray-100" : "text-gray-700 dark:text-gray-300"
+              }`}
+            >
+              <span className="w-12">{DAY_LABELS[d]}</span>
+              <span>
+                {ranges.length === 0
+                  ? <span className="text-gray-400 dark:text-gray-500">Closed</span>
+                  : ranges.map((r) => `${r.open}–${r.close}`).join(", ")}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
 
 interface LocationDetailPanelProps {
   slug: string;
@@ -333,6 +380,10 @@ export default function LocationDetailPanel({
         {location.type === "beach" && <BeachDetailsSection details={location.details} />}
         {location.type === "event" && <EventDetailsSection details={location.details} />}
       </section>
+
+      {location.openingHours && location.openingHours.length > 0 && (
+        <OpeningHoursSection entries={location.openingHours} />
+      )}
 
       {/* Common info */}
       <section className="mb-4">

--- a/src/components/LocationDetailPanel.tsx
+++ b/src/components/LocationDetailPanel.tsx
@@ -32,11 +32,11 @@ const DURATION_DISPLAY: Record<Duration, string> = {
 
 import CostIndicator from "./CostIndicator";
 import SourceAttribution from "./SourceAttribution";
-import { DAYS, DAY_LABELS, entriesForDay, formatHoursStatus } from "@/lib/openingHours";
+import { DAYS, DAY_LABELS, entriesForDay, formatHoursStatus, todayIdx } from "@/lib/openingHours";
 import type { OpeningHoursEntry } from "@/lib/types";
 
 function OpeningHoursSection({ entries }: { entries: OpeningHoursEntry[] }) {
-  const todayIdx = (new Date().getDay() + 6) % 7;
+  const todayIndex = todayIdx();
   const status = formatHoursStatus(entries);
   return (
     <section className="mb-4">
@@ -58,7 +58,7 @@ function OpeningHoursSection({ entries }: { entries: OpeningHoursEntry[] }) {
       <ul className="text-sm">
         {DAYS.map((d, i) => {
           const ranges = entriesForDay(entries, d);
-          const isToday = i === todayIdx;
+          const isToday = i === todayIndex;
           return (
             <li
               key={d}

--- a/src/components/LocationMap.tsx
+++ b/src/components/LocationMap.tsx
@@ -10,7 +10,7 @@ import { Crosshair } from "lucide-react";
 
 import type { PlaceIndexEntry, PlaceType, Coordinates, OpeningHoursEntry } from "@/lib/types";
 import type { ScoredPlace } from "@/lib/constraints";
-import { DAYS, DAY_LETTERS, isOpenOnDay } from "@/lib/openingHours";
+import { DAYS, DAY_LETTERS, isOpenOnDay, todayIdx } from "@/lib/openingHours";
 
 /**
  * Sets the map view so that `latLng` appears centered in the visible area
@@ -73,18 +73,23 @@ const PIN_ICONS: Record<PlaceType, string> = {
 function buildHoursStripHtml(
   entries: OpeningHoursEntry[] | undefined,
   color: string,
-  todayIdx: number,
+  todayIndex: number,
 ): string {
   if (!entries || entries.length === 0) return "";
   const cells = DAYS.map((d, i) => {
     const open = isOpenOnDay(entries, d);
     const classes = ["pin-flag-day"];
     if (open) classes.push("open");
-    if (i === todayIdx) classes.push("today");
-    const style = open ? `style="background:${color};"` : "";
+    if (i === todayIndex) classes.push("today");
+    const style = open ? `style="background:${escapeColor(color)};"` : "";
     return `<span class="${classes.join(" ")}" ${style}>${DAY_LETTERS[d]}</span>`;
   }).join("");
   return `<div class="pin-flag-hours">${cells}</div>`;
+}
+
+/** Whitelist for color values interpolated into inline style attributes. */
+function escapeColor(color: string): string {
+  return /^#[0-9a-fA-F]{3,8}$/.test(color) ? color : "#6b7280";
 }
 
 function createPinIcon(
@@ -96,8 +101,7 @@ function createPinIcon(
 ): L.DivIcon {
   const color = PIN_COLORS[type];
   const svgPaths = PIN_ICONS[type];
-  const todayIdx = (new Date().getDay() + 6) % 7;
-  const hoursHtml = buildHoursStripHtml(openingHours, color, todayIdx);
+  const hoursHtml = buildHoursStripHtml(openingHours, color, todayIdx());
   const labelHtml = name
     ? `<div class="pin-flag"><div class="pin-flag-row"><div class="pin-flag-dot" style="background:${color};"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">${svgPaths}</svg></div><span class="pin-flag-text">${name}</span></div>${hoursHtml}</div>`
     : "";

--- a/src/components/LocationMap.tsx
+++ b/src/components/LocationMap.tsx
@@ -8,8 +8,9 @@ import "leaflet.markercluster/dist/MarkerCluster.css";
 import "leaflet.markercluster/dist/MarkerCluster.Default.css";
 import { Crosshair } from "lucide-react";
 
-import type { PlaceIndexEntry, PlaceType, Coordinates } from "@/lib/types";
+import type { PlaceIndexEntry, PlaceType, Coordinates, OpeningHoursEntry } from "@/lib/types";
 import type { ScoredPlace } from "@/lib/constraints";
+import { DAYS, DAY_LETTERS, isOpenOnDay } from "@/lib/openingHours";
 
 /**
  * Sets the map view so that `latLng` appears centered in the visible area
@@ -69,11 +70,36 @@ const PIN_ICONS: Record<PlaceType, string> = {
   museum: `<path d="M10 18v-7"/><path d="M11.12 2.198a2 2 0 0 1 1.76.006l7.866 3.847c.476.233.31.949-.22.949H3.474c-.53 0-.695-.716-.22-.949z"/><path d="M14 18v-7"/><path d="M18 18v-7"/><path d="M3 22h18"/><path d="M6 18v-7"/>`,
 };
 
-function createPinIcon(type: PlaceType, opacity = 1, name?: string, slug?: string): L.DivIcon {
+function buildHoursStripHtml(
+  entries: OpeningHoursEntry[] | undefined,
+  color: string,
+  todayIdx: number,
+): string {
+  if (!entries || entries.length === 0) return "";
+  const cells = DAYS.map((d, i) => {
+    const open = isOpenOnDay(entries, d);
+    const classes = ["pin-flag-day"];
+    if (open) classes.push("open");
+    if (i === todayIdx) classes.push("today");
+    const style = open ? `style="background:${color};"` : "";
+    return `<span class="${classes.join(" ")}" ${style}>${DAY_LETTERS[d]}</span>`;
+  }).join("");
+  return `<div class="pin-flag-hours">${cells}</div>`;
+}
+
+function createPinIcon(
+  type: PlaceType,
+  opacity = 1,
+  name?: string,
+  slug?: string,
+  openingHours?: OpeningHoursEntry[],
+): L.DivIcon {
   const color = PIN_COLORS[type];
   const svgPaths = PIN_ICONS[type];
+  const todayIdx = (new Date().getDay() + 6) % 7;
+  const hoursHtml = buildHoursStripHtml(openingHours, color, todayIdx);
   const labelHtml = name
-    ? `<div class="pin-flag"><div class="pin-flag-dot" style="background:${color};"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">${svgPaths}</svg></div><span class="pin-flag-text">${name}</span></div>`
+    ? `<div class="pin-flag"><div class="pin-flag-row"><div class="pin-flag-dot" style="background:${color};"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">${svgPaths}</svg></div><span class="pin-flag-text">${name}</span></div>${hoursHtml}</div>`
     : "";
   return L.divIcon({
     className: "",
@@ -320,7 +346,7 @@ export default function LocationMap({
       }
 
       const marker = L.marker([loc.coordinates.lat, loc.coordinates.lng], {
-        icon: createPinIcon(loc.type, pinOpacity, loc.name, loc.slug),
+        icon: createPinIcon(loc.type, pinOpacity, loc.name, loc.slug, loc.openingHours),
       });
 
       if (clusterGroup) clusterGroup.addLayer(marker);

--- a/src/lib/openingHours.ts
+++ b/src/lib/openingHours.ts
@@ -1,0 +1,85 @@
+import type { DayOfWeek, OpeningHoursEntry } from "./types";
+
+export const DAYS: DayOfWeek[] = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
+
+export const DAY_LABELS: Record<DayOfWeek, string> = {
+  mon: "Mon",
+  tue: "Tue",
+  wed: "Wed",
+  thu: "Thu",
+  fri: "Fri",
+  sat: "Sat",
+  sun: "Sun",
+};
+
+export const DAY_LETTERS: Record<DayOfWeek, string> = {
+  mon: "M",
+  tue: "T",
+  wed: "W",
+  thu: "T",
+  fri: "F",
+  sat: "S",
+  sun: "S",
+};
+
+function toMinutes(hhmm: string): number {
+  const [h, m] = hhmm.split(":").map(Number);
+  return h * 60 + m;
+}
+
+function dayOfWeek(date: Date): DayOfWeek {
+  return DAYS[(date.getDay() + 6) % 7];
+}
+
+function prevDay(day: DayOfWeek): DayOfWeek {
+  return DAYS[(DAYS.indexOf(day) + 6) % 7];
+}
+
+export function entriesForDay(
+  entries: OpeningHoursEntry[],
+  day: DayOfWeek,
+): OpeningHoursEntry[] {
+  return entries.filter((e) => e.days.includes(day));
+}
+
+export function isOpenOnDay(entries: OpeningHoursEntry[], day: DayOfWeek): boolean {
+  return entriesForDay(entries, day).length > 0;
+}
+
+export function isOpenAt(entries: OpeningHoursEntry[], date: Date): boolean {
+  const today = dayOfWeek(date);
+  const yesterday = prevDay(today);
+  const mins = date.getHours() * 60 + date.getMinutes();
+
+  for (const e of entriesForDay(entries, today)) {
+    const open = toMinutes(e.open);
+    const close = toMinutes(e.close);
+    if (close > open) {
+      if (mins >= open && mins < close) return true;
+    } else {
+      // Overnight range starting today
+      if (mins >= open) return true;
+    }
+  }
+  // Overnight range carried over from yesterday
+  for (const e of entriesForDay(entries, yesterday)) {
+    const open = toMinutes(e.open);
+    const close = toMinutes(e.close);
+    if (close <= open && mins < close) return true;
+  }
+  return false;
+}
+
+export interface HoursStatus {
+  open: boolean;
+  label: string;
+}
+
+export function formatHoursStatus(
+  entries: OpeningHoursEntry[] | undefined,
+  date: Date = new Date(),
+): HoursStatus | null {
+  if (!entries || entries.length === 0) return null;
+  const open = isOpenAt(entries, date);
+  return { open, label: open ? "Open now" : "Closed" };
+}

--- a/src/lib/openingHours.ts
+++ b/src/lib/openingHours.ts
@@ -28,7 +28,12 @@ function toMinutes(hhmm: string): number {
 }
 
 function dayOfWeek(date: Date): DayOfWeek {
-  return DAYS[(date.getDay() + 6) % 7];
+  return DAYS[todayIdx(date)];
+}
+
+/** Monday-origin weekday index (0 = Mon … 6 = Sun). */
+export function todayIdx(date: Date = new Date()): number {
+  return (date.getDay() + 6) % 7;
 }
 
 function prevDay(day: DayOfWeek): DayOfWeek {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -208,6 +208,7 @@ export interface PlaceIndexEntry {
   route?: [number, number][]; // only present for walk/bushwalk type
   fit?: FitBlurbs;
   source?: { provider: string; url: string };
+  openingHours?: OpeningHoursEntry[];
 }
 
 // ── Filters (updated for new types) ──────────────────────────


### PR DESCRIPTION
## Summary
- New `openingHours` helper library with overnight-range aware open/closed logic (12 unit tests)
- `openingHours` now flows through `PlaceIndexEntry` and the generated locations index
- Three UI surfaces: Open/Closed badge on `LocationCard`, expand-on-hover/active day strip inside the map pin flag (neutral flag, cells coloured by pin type, today outlined), and full weekly schedule section on `LocationDetailPanel`
- Backfilled schedules for the two museum POIs (best-guess, should be verified against official sources)

## Test plan
- [ ] At zoom ≥ 12, hover or select a museum pin — day strip expands under the name with today outlined
- [ ] Detail panel shows weekly hours with today bolded and correct Open now / Closed badge
- [ ] List card shows compact Open now / Closed badge for museums, nothing for POIs without hours
- [ ] POIs without `openingHours` render unchanged in all three surfaces
- [ ] Day cells stay fixed-width regardless of POI name length