### PR TITLE
ci: add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      # Lint is currently excluded — main has pre-existing errors.
+      # Re-enable once those are resolved.
+      # - run: npm run lint
+
+      - run: npm test
+
+      - run: npm run build

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./__tests__/setup-firebase-mock.ts"],
-    exclude: ["e2e/**", "node_modules/**"],
+    exclude: ["e2e/**", "node_modules/**", ".claude/**"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` running vitest + `npm run build` on PR and push to main. Build triggers the `prebuild` hook, so YAML validation runs too.
- Lint is commented out pending cleanup of 34 pre-existing errors on main.
- Fixes vitest picking up stale test files from local git worktrees inside `.claude/` — this turned out to be the entire cause of the "10 failing integration tests" I'd been flagging. All 157 tests now pass on a clean run.

## Test plan
- [ ] CI run succeeds on this PR
- [ ] Intentionally break a unit test on a throwaway branch and confirm CI catches it
- [ ] Once pre-existing lint errors are resolved, uncomment the `npm run lint` step