### PR TITLE
feat: collapse desktop filter bar to single row with hover expand

### DIFF
--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { Search } from "lucide-react";
 import type { Filters, PlaceType, SiteStatus } from "@/lib/types";
 
@@ -43,27 +43,38 @@ export default function FilterBar({
   const hasActiveFilters =
     filters.type || filters.siteStatus || filters.search;
 
-  // Desktop collapse/expand: measure full height, show single row by default
   const chipsRef = useRef<HTMLDivElement>(null);
   const [collapsed, setCollapsed] = useState(true);
   const [collapsedHeight, setCollapsedHeight] = useState<number | null>(null);
   const [fullHeight, setFullHeight] = useState<number | null>(null);
 
+  // When collapsed, promote the active type chip to the front so it's visible
+  const orderedTypeChips = useMemo(() => {
+    if (!collapsed || !filters.type) return TYPE_CHIPS;
+    const active = TYPE_CHIPS.find((c) => c.value === filters.type);
+    if (!active) return TYPE_CHIPS;
+    return [active, ...TYPE_CHIPS.filter((c) => c.value !== filters.type)];
+  }, [collapsed, filters.type]);
+
+  const orderedStatusChips = useMemo(() => {
+    if (!collapsed || !filters.siteStatus) return STATUS_CHIPS;
+    const active = STATUS_CHIPS.find((c) => c.value === filters.siteStatus);
+    if (!active) return STATUS_CHIPS;
+    return [active, ...STATUS_CHIPS.filter((c) => c.value !== filters.siteStatus)];
+  }, [collapsed, filters.siteStatus]);
+
   const measure = useCallback(() => {
     const el = chipsRef.current;
     if (!el || window.innerWidth < 768) return;
-    // Temporarily expand to measure full height
     el.style.maxHeight = "none";
     el.style.overflow = "visible";
     const full = el.scrollHeight;
-    // Measure single-row height (first child's offsetTop + its height gives one row)
     const firstChip = el.querySelector("button") as HTMLElement | null;
     const single = firstChip
       ? firstChip.offsetHeight + parseInt(getComputedStyle(el).paddingTop) * 2
       : 36;
     setFullHeight(full);
     setCollapsedHeight(single);
-    // Restore collapsed state
     if (collapsed) {
       el.style.maxHeight = `${single}px`;
       el.style.overflow = "hidden";
@@ -89,13 +100,12 @@ export default function FilterBar({
     setCollapsed(true);
   }, []);
 
-  // Derive inline style for the chips container on desktop
   const chipsStyle: React.CSSProperties =
     collapsedHeight !== null && fullHeight !== null
       ? {
           maxHeight: collapsed ? `${collapsedHeight}px` : `${fullHeight}px`,
           overflow: collapsed ? "hidden" : "visible",
-          transition: "max-height 0.2s ease",
+          transition: "max-height 0.25s cubic-bezier(0.4, 0, 0.2, 1)",
         }
       : {};
 
@@ -123,7 +133,7 @@ export default function FilterBar({
         className="flex items-center gap-2 px-3 py-2 overflow-x-auto scrollbar-hide md:flex-wrap md:overflow-x-visible"
         style={chipsStyle}
       >
-        {TYPE_CHIPS.map((chip) => {
+        {orderedTypeChips.map((chip) => {
           const isActive = filters.type === chip.value;
           return (
             <button
@@ -148,7 +158,7 @@ export default function FilterBar({
 
         <div className="w-px h-5 bg-gray-200 dark:bg-gray-700 shrink-0" />
 
-        {STATUS_CHIPS.map((chip) => {
+        {orderedStatusChips.map((chip) => {
           const isActive = filters.siteStatus === chip.value;
           return (
             <button

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback, useMemo } from "react";
+import { useState, useRef, useEffect, useCallback, useMemo, useLayoutEffect } from "react";
 import { Search } from "lucide-react";
 import type { Filters, PlaceType, SiteStatus } from "@/lib/types";
 
@@ -27,11 +27,59 @@ const STATUS_CHIPS: { value: SiteStatus; label: string }[] = [
   { value: "seasonal", label: "Seasonal" },
 ];
 
+const FLIP_DURATION = 300;
+
 interface FilterBarProps {
   filters: Filters;
   onChange: (filters: Filters) => void;
   resultCount: number;
   hideSearch?: boolean;
+}
+
+// FLIP animation: snapshot positions before render, animate after
+function useFlip(containerRef: React.RefObject<HTMLDivElement | null>, deps: unknown[]) {
+  const prevRects = useRef<Map<string, DOMRect>>(new Map());
+
+  // Capture "First" positions before DOM update
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useLayoutEffect(() => {
+    const el = containerRef.current;
+    if (!el || window.innerWidth < 768) return;
+    const chips = el.querySelectorAll<HTMLElement>("[data-filter-chip]");
+    const rects = new Map<string, DOMRect>();
+    chips.forEach((chip) => {
+      const key = chip.getAttribute("data-filter-chip")!;
+      rects.set(key, chip.getBoundingClientRect());
+    });
+    prevRects.current = rects;
+  });
+
+  // Play animation after DOM update
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || window.innerWidth < 768) return;
+    const prev = prevRects.current;
+    if (prev.size === 0) return;
+
+    const chips = el.querySelectorAll<HTMLElement>("[data-filter-chip]");
+    chips.forEach((chip) => {
+      const key = chip.getAttribute("data-filter-chip")!;
+      const oldRect = prev.get(key);
+      if (!oldRect) return;
+      const newRect = chip.getBoundingClientRect();
+      const dx = oldRect.left - newRect.left;
+      const dy = oldRect.top - newRect.top;
+      if (Math.abs(dx) < 1 && Math.abs(dy) < 1) return;
+
+      chip.style.transform = `translate(${dx}px, ${dy}px)`;
+      chip.style.transition = "none";
+      requestAnimationFrame(() => {
+        chip.style.transition = `transform ${FLIP_DURATION}ms cubic-bezier(0.4, 0, 0.2, 1)`;
+        chip.style.transform = "";
+      });
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
 }
 
 export default function FilterBar({
@@ -64,6 +112,9 @@ export default function FilterBar({
     return [active, ...STATUS_CHIPS.filter((c) => c.value !== filters.siteStatus)];
   }, [filters.siteStatus]);
 
+  // Animate chip reordering with FLIP
+  useFlip(chipsRef, [filters.type, filters.siteStatus]);
+
   // Measure heights without touching inline styles — let React handle rendering
   useEffect(() => {
     const el = chipsRef.current;
@@ -74,18 +125,15 @@ export default function FilterBar({
       setIsDesktop(desktop);
       if (!desktop) return;
 
-      // Temporarily remove constraints to measure natural full height
       const prev = el.style.cssText;
       el.style.maxHeight = "none";
       el.style.overflow = "visible";
       const full = el.scrollHeight;
 
-      // Measure single-row height from first chip
       const firstChip = el.querySelector("button") as HTMLElement | null;
       const py = parseFloat(getComputedStyle(el).paddingTop) || 0;
       const single = firstChip ? firstChip.offsetHeight + py * 2 : 36;
 
-      // Restore previous styles before React re-renders
       el.style.cssText = prev;
 
       setRowHeight(single);
@@ -107,12 +155,11 @@ export default function FilterBar({
     setCollapsed(true);
   }, []);
 
-  // Only apply collapse styles on desktop
   const chipsStyle: React.CSSProperties = isDesktop
     ? {
         maxHeight: collapsed ? `${rowHeight}px` : `${fullHeight}px`,
         overflow: "hidden",
-        transition: "max-height 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
+        transition: `max-height ${FLIP_DURATION}ms cubic-bezier(0.4, 0, 0.2, 1)`,
       }
     : {};
 

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useRef, useEffect, useCallback } from "react";
 import { Search } from "lucide-react";
 import type { Filters, PlaceType, SiteStatus } from "@/lib/types";
 
@@ -42,8 +43,68 @@ export default function FilterBar({
   const hasActiveFilters =
     filters.type || filters.siteStatus || filters.search;
 
+  // Desktop collapse/expand: measure full height, show single row by default
+  const chipsRef = useRef<HTMLDivElement>(null);
+  const [collapsed, setCollapsed] = useState(true);
+  const [collapsedHeight, setCollapsedHeight] = useState<number | null>(null);
+  const [fullHeight, setFullHeight] = useState<number | null>(null);
+
+  const measure = useCallback(() => {
+    const el = chipsRef.current;
+    if (!el || window.innerWidth < 768) return;
+    // Temporarily expand to measure full height
+    el.style.maxHeight = "none";
+    el.style.overflow = "visible";
+    const full = el.scrollHeight;
+    // Measure single-row height (first child's offsetTop + its height gives one row)
+    const firstChip = el.querySelector("button") as HTMLElement | null;
+    const single = firstChip
+      ? firstChip.offsetHeight + parseInt(getComputedStyle(el).paddingTop) * 2
+      : 36;
+    setFullHeight(full);
+    setCollapsedHeight(single);
+    // Restore collapsed state
+    if (collapsed) {
+      el.style.maxHeight = `${single}px`;
+      el.style.overflow = "hidden";
+    } else {
+      el.style.maxHeight = `${full}px`;
+      el.style.overflow = "visible";
+    }
+  }, [collapsed]);
+
+  useEffect(() => {
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, [measure, filters, hasActiveFilters]);
+
+  const handleMouseEnter = useCallback(() => {
+    if (window.innerWidth < 768) return;
+    setCollapsed(false);
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    if (window.innerWidth < 768) return;
+    setCollapsed(true);
+  }, []);
+
+  // Derive inline style for the chips container on desktop
+  const chipsStyle: React.CSSProperties =
+    collapsedHeight !== null && fullHeight !== null
+      ? {
+          maxHeight: collapsed ? `${collapsedHeight}px` : `${fullHeight}px`,
+          overflow: collapsed ? "hidden" : "visible",
+          transition: "max-height 0.2s ease",
+        }
+      : {};
+
   return (
-    <div className="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900">
+    <div
+      className="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
       {!hideSearch && (
         <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-100 dark:border-gray-800">
           <Search className="w-4 h-4 text-gray-400 dark:text-gray-500 shrink-0" />
@@ -57,7 +118,11 @@ export default function FilterBar({
           />
         </div>
       )}
-      <div className="flex items-center gap-2 px-3 py-2 overflow-x-auto scrollbar-hide md:flex-wrap md:overflow-x-visible">
+      <div
+        ref={chipsRef}
+        className="flex items-center gap-2 px-3 py-2 overflow-x-auto scrollbar-hide md:flex-wrap md:overflow-x-visible"
+        style={chipsStyle}
+      >
         {TYPE_CHIPS.map((chip) => {
           const isActive = filters.type === chip.value;
           return (

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -45,50 +45,57 @@ export default function FilterBar({
 
   const chipsRef = useRef<HTMLDivElement>(null);
   const [collapsed, setCollapsed] = useState(true);
-  const [collapsedHeight, setCollapsedHeight] = useState<number | null>(null);
-  const [fullHeight, setFullHeight] = useState<number | null>(null);
+  const [rowHeight, setRowHeight] = useState<number>(36);
+  const [fullHeight, setFullHeight] = useState<number>(36);
+  const [isDesktop, setIsDesktop] = useState(false);
 
-  // When collapsed, promote the active type chip to the front so it's visible
+  // Always promote active chip to front so it's visible when collapsed
   const orderedTypeChips = useMemo(() => {
-    if (!collapsed || !filters.type) return TYPE_CHIPS;
+    if (!filters.type) return TYPE_CHIPS;
     const active = TYPE_CHIPS.find((c) => c.value === filters.type);
     if (!active) return TYPE_CHIPS;
     return [active, ...TYPE_CHIPS.filter((c) => c.value !== filters.type)];
-  }, [collapsed, filters.type]);
+  }, [filters.type]);
 
   const orderedStatusChips = useMemo(() => {
-    if (!collapsed || !filters.siteStatus) return STATUS_CHIPS;
+    if (!filters.siteStatus) return STATUS_CHIPS;
     const active = STATUS_CHIPS.find((c) => c.value === filters.siteStatus);
     if (!active) return STATUS_CHIPS;
     return [active, ...STATUS_CHIPS.filter((c) => c.value !== filters.siteStatus)];
-  }, [collapsed, filters.siteStatus]);
+  }, [filters.siteStatus]);
 
-  const measure = useCallback(() => {
-    const el = chipsRef.current;
-    if (!el || window.innerWidth < 768) return;
-    el.style.maxHeight = "none";
-    el.style.overflow = "visible";
-    const full = el.scrollHeight;
-    const firstChip = el.querySelector("button") as HTMLElement | null;
-    const single = firstChip
-      ? firstChip.offsetHeight + parseInt(getComputedStyle(el).paddingTop) * 2
-      : 36;
-    setFullHeight(full);
-    setCollapsedHeight(single);
-    if (collapsed) {
-      el.style.maxHeight = `${single}px`;
-      el.style.overflow = "hidden";
-    } else {
-      el.style.maxHeight = `${full}px`;
-      el.style.overflow = "visible";
-    }
-  }, [collapsed]);
-
+  // Measure heights without touching inline styles — let React handle rendering
   useEffect(() => {
-    measure();
-    window.addEventListener("resize", measure);
-    return () => window.removeEventListener("resize", measure);
-  }, [measure, filters, hasActiveFilters]);
+    const el = chipsRef.current;
+    if (!el) return;
+
+    const remeasure = () => {
+      const desktop = window.innerWidth >= 768;
+      setIsDesktop(desktop);
+      if (!desktop) return;
+
+      // Temporarily remove constraints to measure natural full height
+      const prev = el.style.cssText;
+      el.style.maxHeight = "none";
+      el.style.overflow = "visible";
+      const full = el.scrollHeight;
+
+      // Measure single-row height from first chip
+      const firstChip = el.querySelector("button") as HTMLElement | null;
+      const py = parseFloat(getComputedStyle(el).paddingTop) || 0;
+      const single = firstChip ? firstChip.offsetHeight + py * 2 : 36;
+
+      // Restore previous styles before React re-renders
+      el.style.cssText = prev;
+
+      setRowHeight(single);
+      setFullHeight(full);
+    };
+
+    remeasure();
+    window.addEventListener("resize", remeasure);
+    return () => window.removeEventListener("resize", remeasure);
+  }, [filters, hasActiveFilters]);
 
   const handleMouseEnter = useCallback(() => {
     if (window.innerWidth < 768) return;
@@ -100,14 +107,14 @@ export default function FilterBar({
     setCollapsed(true);
   }, []);
 
-  const chipsStyle: React.CSSProperties =
-    collapsedHeight !== null && fullHeight !== null
-      ? {
-          maxHeight: collapsed ? `${collapsedHeight}px` : `${fullHeight}px`,
-          overflow: collapsed ? "hidden" : "visible",
-          transition: "max-height 0.25s cubic-bezier(0.4, 0, 0.2, 1)",
-        }
-      : {};
+  // Only apply collapse styles on desktop
+  const chipsStyle: React.CSSProperties = isDesktop
+    ? {
+        maxHeight: collapsed ? `${rowHeight}px` : `${fullHeight}px`,
+        overflow: "hidden",
+        transition: "max-height 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
+      }
+    : {};
 
   return (
     <div

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -36,15 +36,13 @@ interface FilterBarProps {
   hideSearch?: boolean;
 }
 
-// FLIP animation: snapshot positions before render, animate after
+// FLIP animation: snapshot positions during render, animate after DOM commit
 function useFlip(containerRef: React.RefObject<HTMLDivElement | null>, deps: unknown[]) {
   const prevRects = useRef<Map<string, DOMRect>>(new Map());
 
-  // Capture "First" positions before DOM update
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useLayoutEffect(() => {
+  // Snapshot "First" positions during render — DOM still has old layout
+  if (typeof window !== "undefined" && containerRef.current) {
     const el = containerRef.current;
-    if (!el || window.innerWidth < 768) return;
     const chips = el.querySelectorAll<HTMLElement>("[data-filter-chip]");
     const rects = new Map<string, DOMRect>();
     chips.forEach((chip) => {
@@ -52,10 +50,11 @@ function useFlip(containerRef: React.RefObject<HTMLDivElement | null>, deps: unk
       rects.set(key, chip.getBoundingClientRect());
     });
     prevRects.current = rects;
-  });
+  }
 
-  // Play animation after DOM update
-  useEffect(() => {
+  // After DOM commit, compare old→new and animate
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useLayoutEffect(() => {
     const el = containerRef.current;
     if (!el || window.innerWidth < 768) return;
     const prev = prevRects.current;
@@ -71,14 +70,16 @@ function useFlip(containerRef: React.RefObject<HTMLDivElement | null>, deps: unk
       const dy = oldRect.top - newRect.top;
       if (Math.abs(dx) < 1 && Math.abs(dy) < 1) return;
 
+      // Invert: place chip at old position
       chip.style.transform = `translate(${dx}px, ${dy}px)`;
       chip.style.transition = "none";
+
+      // Play: animate to new position on next frame
       requestAnimationFrame(() => {
         chip.style.transition = `transform ${FLIP_DURATION}ms cubic-bezier(0.4, 0, 0.2, 1)`;
         chip.style.transform = "";
       });
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps);
 }
 


### PR DESCRIPTION
## Summary

On desktop (md+), the filter chip bar now collapses to a **single row** by default, reducing visual clutter. Hovering over the bar smoothly expands it to reveal all filter chips.

### Changes

- **Collapse/expand on hover** — Single row collapsed state with 300ms animated expand/collapse on mouse enter/leave
- **Active filter promotion** — When a filter is selected, the active chip is promoted to the first position so it's always visible even when collapsed
- **FLIP animation** — Chip reordering is animated using the FLIP technique (First-Last-Invert-Play) so chips slide smoothly to their new positions
- **Mobile unchanged** — Horizontal scroll behavior on mobile is preserved

### Technical details

- Positions are captured during the render phase (before DOM commit) and compared in `useLayoutEffect` to calculate deltas for the FLIP animation
- Height measurement is separated from style application so React controls inline styles and CSS transitions work correctly
- `max-height` transition with `cubic-bezier(0.4, 0, 0.2, 1)` easing for the expand/collapse