### PR TITLE
feat: full-bleed photo location cards with edge-color gradient

### DIFF
--- a/__tests__/setup-firebase-mock.ts
+++ b/__tests__/setup-firebase-mock.ts
@@ -1,6 +1,22 @@
 // Mock Firebase modules for test environment
 import { vi } from "vitest";
 
+// jsdom doesn't provide IntersectionObserver — stub it so useEdgeColor works
+if (typeof globalThis.IntersectionObserver === "undefined") {
+  globalThis.IntersectionObserver = class IntersectionObserver {
+    constructor(private cb: IntersectionObserverCallback) {}
+    observe(target: Element) {
+      // Immediately report as intersecting so hooks proceed in tests
+      this.cb(
+        [{ isIntersecting: true, target } as IntersectionObserverEntry],
+        this as unknown as IntersectionObserver,
+      );
+    }
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof IntersectionObserver;
+}
+
 vi.mock("firebase/app", () => ({
   initializeApp: vi.fn(() => ({})),
   getApps: vi.fn(() => []),

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -134,10 +134,10 @@ export default function LocationCard({
         style={
           gradientColor
             ? {
-                background: `linear-gradient(to right, rgba(${gradientColor}, 1) 10%, transparent 60%)`,
+                background: `linear-gradient(to right, rgb(${gradientColor}) 35%, transparent 80%)`,
               }
             : {
-                background: "linear-gradient(to right, rgba(0,0,0,1) 10%, transparent 60%)",
+                background: "linear-gradient(to right, rgb(0,0,0) 35%, transparent 80%)",
               }
         }
       />

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import type { PlaceIndexEntry, Coordinates, Constraints } from "@/lib/types";
 import { haversineDistanceKm, formatDistance } from "@/lib/useCurrentLocation";
 import { buildFitParagraph } from "@/lib/fit";
-import { useEdgeColor } from "@/lib/useEdgeColor";
+import { useEdgeColor, darkenEdgeColor } from "@/lib/useEdgeColor";
 import TypeBadge from "./TypeBadge";
 import StatusBadge from "./StatusBadge";
 import CostIndicator from "./CostIndicator";
@@ -47,18 +47,8 @@ export default function LocationCard({
   const hoursStatus = formatHoursStatus(location.openingHours);
 
   const edgeColor = useEdgeColor(photo);
-
-  // Determine if text over the gradient should be dark based on edge color luminance
-  const isDarkBg = (() => {
-    if (!edgeColor) return true; // fallback gradient is black
-    const [r, g, b] = edgeColor.split(",").map(Number);
-    // Perceived brightness (ITU-R BT.601)
-    return 0.299 * r + 0.587 * g + 0.114 * b < 140;
-  })();
-  const photoTextColor = isDarkBg ? "text-white" : "text-gray-900";
-  const photoTextMuted = isDarkBg ? "text-white/80" : "text-gray-700";
-  const photoTextFaint = isDarkBg ? "text-white/70" : "text-gray-600";
-  const photoShadow = isDarkBg ? "drop-shadow-[0_1px_3px_rgba(0,0,0,0.6)]" : "drop-shadow-[0_1px_2px_rgba(255,255,255,0.3)]";
+  // Always darken the edge color so white text is readable over the gradient
+  const gradientColor = edgeColor ? darkenEdgeColor(edgeColor) : null;
 
   const cardClassName = `block rounded-lg border overflow-hidden transition-all duration-100 active:scale-[0.98] active:shadow-none ${
     isHighlighted
@@ -68,11 +58,11 @@ export default function LocationCard({
 
   // Shared bottom row: highlights / fit / tags
   const bottomRow = fitBlurb ? (
-    <p className={`text-sm mt-1.5 line-clamp-2 ${photo ? `${photoTextColor}/90 ${photoShadow}` : "text-emerald-700 dark:text-emerald-400"}`}>
+    <p className={`text-sm mt-1.5 line-clamp-2 ${photo ? "text-white/90 drop-shadow-[0_1px_3px_rgba(0,0,0,0.6)]" : "text-emerald-700 dark:text-emerald-400"}`}>
       {fitBlurb}
     </p>
   ) : location.highlights.length > 0 ? (
-    <p className={`text-sm mt-1.5 line-clamp-1 ${photo ? `${photoTextMuted} ${photoShadow}` : "text-gray-600 dark:text-gray-400"}`}>
+    <p className={`text-sm mt-1.5 line-clamp-1 ${photo ? "text-white/80 drop-shadow-[0_1px_3px_rgba(0,0,0,0.6)]" : "text-gray-600 dark:text-gray-400"}`}>
       {location.highlights[0]}
     </p>
   ) : location.tags.length > 0 ? (
@@ -80,7 +70,7 @@ export default function LocationCard({
       {location.tags.slice(0, 3).map((tag) => (
         <span
           key={tag}
-          className={`px-1.5 py-0.5 text-xs rounded ${photo ? `${isDarkBg ? "bg-white/20 text-white" : "bg-black/10 text-gray-800"} backdrop-blur-sm` : "bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300"}`}
+          className={`px-1.5 py-0.5 text-xs rounded ${photo ? "bg-white/20 text-white backdrop-blur-sm" : "bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300"}`}
         >
           {tag}
         </span>
@@ -90,11 +80,11 @@ export default function LocationCard({
 
   // Meta row: type icon, country, distance, cost, hours, source
   const metaRow = (
-    <div className={`flex items-center gap-2 ${photo ? `[&_span]:${photoTextMuted} [&_span]:${photoShadow}` : ""}`}>
+    <div className={`flex items-center gap-2 ${photo ? "[&_span]:text-white/80 [&_span]:drop-shadow-[0_1px_3px_rgba(0,0,0,0.6)]" : ""}`}>
       <TypeBadge type={location.type} showLabel={false} />
-      <span className={`text-sm ${photo ? `${photoTextMuted} ${photoShadow}` : "text-gray-500 dark:text-gray-400"}`}>{location.country}</span>
+      <span className={`text-sm ${photo ? "text-white/80 drop-shadow-[0_1px_3px_rgba(0,0,0,0.6)]" : "text-gray-500 dark:text-gray-400"}`}>{location.country}</span>
       {distance && (
-        <span className={`text-xs font-medium ${photo ? `${photoTextMuted} ${photoShadow}` : "text-gray-500 dark:text-gray-400"}`}>{distance}</span>
+        <span className={`text-xs font-medium ${photo ? "text-white/80 drop-shadow-[0_1px_3px_rgba(0,0,0,0.6)]" : "text-gray-500 dark:text-gray-400"}`}>{distance}</span>
       )}
       <CostIndicator cost={location.cost} />
       {hoursStatus && (
@@ -102,8 +92,8 @@ export default function LocationCard({
           className={`text-xs font-medium px-1.5 py-0.5 rounded ${
             photo
               ? hoursStatus.open
-                ? `${isDarkBg ? "bg-emerald-500/30 text-white" : "bg-emerald-500/30 text-gray-900"} backdrop-blur-sm`
-                : `${isDarkBg ? "bg-black/20 text-white/70" : "bg-white/30 text-gray-600"} backdrop-blur-sm`
+                ? "bg-emerald-500/30 text-white backdrop-blur-sm"
+                : "bg-black/20 text-white/70 backdrop-blur-sm"
               : hoursStatus.open
                 ? "bg-emerald-50 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-300"
                 : "bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400"
@@ -121,8 +111,8 @@ export default function LocationCard({
     <div
       className="relative w-full overflow-hidden"
       style={
-        edgeColor
-          ? { backgroundColor: `rgb(${edgeColor})` }
+        gradientColor
+          ? { backgroundColor: `rgb(${gradientColor})` }
           : { backgroundColor: "#000" }
       }
     >
@@ -140,9 +130,9 @@ export default function LocationCard({
       <div
         className="absolute inset-0"
         style={
-          edgeColor
+          gradientColor
             ? {
-                background: `linear-gradient(to right, rgba(${edgeColor}, 1) 10%, transparent 60%)`,
+                background: `linear-gradient(to right, rgba(${gradientColor}, 1) 10%, transparent 60%)`,
               }
             : {
                 background: "linear-gradient(to right, rgba(0,0,0,1) 10%, transparent 60%)",
@@ -151,7 +141,7 @@ export default function LocationCard({
       />
       <div className="relative p-3 pt-1.5">
         <div className="flex items-start justify-between gap-2 mb-1">
-          <h3 className={`font-semibold ${photoTextColor} truncate text-sm ${photoShadow}`}>{location.name}</h3>
+          <h3 className={`font-semibold text-white truncate text-sm drop-shadow-[0_1px_3px_rgba(0,0,0,0.6)]`}>{location.name}</h3>
           <div className="shrink-0">
             <StatusBadge status={location.status.site} />
           </div>

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -9,7 +9,6 @@ import TypeBadge from "./TypeBadge";
 import StatusBadge from "./StatusBadge";
 import CostIndicator from "./CostIndicator";
 import SourceAttribution from "./SourceAttribution";
-import Image from "next/image";
 import { formatHoursStatus } from "@/lib/openingHours";
 
 interface LocationCardProps {
@@ -108,13 +107,14 @@ export default function LocationCard({
   const cardContent = photo ? (
     // Full-bleed photo card — image offset right, edge-color gradient on left
     <div className="relative w-full">
-      <Image
+      {/* Plain img for full control over object-position (unoptimized images anyway) */}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
         src={photo}
         alt=""
-        fill
-        className="brightness-90 saturate-[0.85]"
-        style={{ objectFit: "cover", objectPosition: "65% center" }}
-        sizes="(max-width: 768px) 100vw, 400px"
+        loading="lazy"
+        className="absolute inset-0 w-full h-full object-cover brightness-90 saturate-[0.85]"
+        style={{ objectPosition: "65% center" }}
       />
       {/* Left-to-right gradient using extracted edge color, falling back to dark */}
       <div

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -105,14 +105,21 @@ export default function LocationCard({
   );
 
   const cardContent = photo ? (
-    // Full-bleed photo card with edge-color gradient on left
-    <div className="relative w-full">
+    // Full-bleed photo card — image anchored right, gradient fills left gap
+    <div
+      className="relative w-full"
+      style={
+        edgeColor
+          ? { backgroundColor: `rgb(${edgeColor})` }
+          : { backgroundColor: "#000" }
+      }
+    >
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
         src={photo}
         alt=""
         loading="lazy"
-        className="absolute inset-0 w-full h-full object-cover brightness-90 saturate-[0.85]"
+        className="absolute right-0 top-0 h-full w-auto brightness-90 saturate-[0.85]"
       />
       {/* Left-to-right gradient using extracted edge color, falling back to dark */}
       <div

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -48,6 +48,18 @@ export default function LocationCard({
 
   const edgeColor = useEdgeColor(photo);
 
+  // Determine if text over the gradient should be dark based on edge color luminance
+  const isDarkBg = (() => {
+    if (!edgeColor) return true; // fallback gradient is black
+    const [r, g, b] = edgeColor.split(",").map(Number);
+    // Perceived brightness (ITU-R BT.601)
+    return 0.299 * r + 0.587 * g + 0.114 * b < 140;
+  })();
+  const photoTextColor = isDarkBg ? "text-white" : "text-gray-900";
+  const photoTextMuted = isDarkBg ? "text-white/80" : "text-gray-700";
+  const photoTextFaint = isDarkBg ? "text-white/70" : "text-gray-600";
+  const photoShadow = isDarkBg ? "drop-shadow-[0_1px_3px_rgba(0,0,0,0.6)]" : "drop-shadow-[0_1px_2px_rgba(255,255,255,0.3)]";
+
   const cardClassName = `block rounded-lg border overflow-hidden transition-all duration-100 active:scale-[0.98] active:shadow-none ${
     isHighlighted
       ? "border-blue-400 bg-blue-50 dark:bg-blue-950 shadow-md"
@@ -56,11 +68,11 @@ export default function LocationCard({
 
   // Shared bottom row: highlights / fit / tags
   const bottomRow = fitBlurb ? (
-    <p className={`text-sm mt-1.5 line-clamp-2 ${photo ? "text-white/90 drop-shadow-[0_1px_2px_rgba(0,0,0,0.5)]" : "text-emerald-700 dark:text-emerald-400"}`}>
+    <p className={`text-sm mt-1.5 line-clamp-2 ${photo ? `${photoTextColor}/90 ${photoShadow}` : "text-emerald-700 dark:text-emerald-400"}`}>
       {fitBlurb}
     </p>
   ) : location.highlights.length > 0 ? (
-    <p className={`text-sm mt-1.5 line-clamp-1 ${photo ? "text-white/80 drop-shadow-[0_1px_2px_rgba(0,0,0,0.5)]" : "text-gray-600 dark:text-gray-400"}`}>
+    <p className={`text-sm mt-1.5 line-clamp-1 ${photo ? `${photoTextMuted} ${photoShadow}` : "text-gray-600 dark:text-gray-400"}`}>
       {location.highlights[0]}
     </p>
   ) : location.tags.length > 0 ? (
@@ -68,7 +80,7 @@ export default function LocationCard({
       {location.tags.slice(0, 3).map((tag) => (
         <span
           key={tag}
-          className={`px-1.5 py-0.5 text-xs rounded ${photo ? "bg-white/20 text-white backdrop-blur-sm" : "bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300"}`}
+          className={`px-1.5 py-0.5 text-xs rounded ${photo ? `${isDarkBg ? "bg-white/20 text-white" : "bg-black/10 text-gray-800"} backdrop-blur-sm` : "bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300"}`}
         >
           {tag}
         </span>
@@ -78,11 +90,11 @@ export default function LocationCard({
 
   // Meta row: type icon, country, distance, cost, hours, source
   const metaRow = (
-    <div className={`flex items-center gap-2 ${photo ? "[&_span]:text-white/80 [&_span]:drop-shadow-[0_1px_2px_rgba(0,0,0,0.4)]" : ""}`}>
+    <div className={`flex items-center gap-2 ${photo ? `[&_span]:${photoTextMuted} [&_span]:${photoShadow}` : ""}`}>
       <TypeBadge type={location.type} showLabel={false} />
-      <span className={`text-sm ${photo ? "text-white/80 drop-shadow-[0_1px_2px_rgba(0,0,0,0.4)]" : "text-gray-500 dark:text-gray-400"}`}>{location.country}</span>
+      <span className={`text-sm ${photo ? `${photoTextMuted} ${photoShadow}` : "text-gray-500 dark:text-gray-400"}`}>{location.country}</span>
       {distance && (
-        <span className={`text-xs font-medium ${photo ? "text-white/80 drop-shadow-[0_1px_2px_rgba(0,0,0,0.4)]" : "text-gray-500 dark:text-gray-400"}`}>{distance}</span>
+        <span className={`text-xs font-medium ${photo ? `${photoTextMuted} ${photoShadow}` : "text-gray-500 dark:text-gray-400"}`}>{distance}</span>
       )}
       <CostIndicator cost={location.cost} />
       {hoursStatus && (
@@ -90,8 +102,8 @@ export default function LocationCard({
           className={`text-xs font-medium px-1.5 py-0.5 rounded ${
             photo
               ? hoursStatus.open
-                ? "bg-emerald-500/30 text-white backdrop-blur-sm"
-                : "bg-black/20 text-white/70 backdrop-blur-sm"
+                ? `${isDarkBg ? "bg-emerald-500/30 text-white" : "bg-emerald-500/30 text-gray-900"} backdrop-blur-sm`
+                : `${isDarkBg ? "bg-black/20 text-white/70" : "bg-white/30 text-gray-600"} backdrop-blur-sm`
               : hoursStatus.open
                 ? "bg-emerald-50 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-300"
                 : "bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400"
@@ -139,7 +151,7 @@ export default function LocationCard({
       />
       <div className="relative p-3 pt-1.5">
         <div className="flex items-start justify-between gap-2 mb-1">
-          <h3 className="font-semibold text-white truncate text-sm drop-shadow-[0_1px_3px_rgba(0,0,0,0.6)]">{location.name}</h3>
+          <h3 className={`font-semibold ${photoTextColor} truncate text-sm ${photoShadow}`}>{location.name}</h3>
           <div className="shrink-0">
             <StatusBadge status={location.status.site} />
           </div>

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -101,8 +101,8 @@ export default function LocationCard({
   );
 
   const cardContent = photo ? (
-    // Full-bleed photo card
-    <div className="relative w-full h-32">
+    // Full-bleed photo card — content-sized, image fills as background
+    <div className="relative w-full">
       <Image
         src={photo}
         alt=""
@@ -111,8 +111,8 @@ export default function LocationCard({
         sizes="(max-width: 768px) 100vw, 400px"
       />
       <div className="absolute inset-0 bg-gradient-to-b from-black/10 via-black/20 via-40% to-black/70" />
-      <div className="absolute inset-0 flex flex-col justify-end p-3 gap-0.5">
-        <div className="flex items-end justify-between gap-2">
+      <div className="relative p-3 pt-1.5">
+        <div className="flex items-start justify-between gap-2 mb-1">
           <h3 className="font-semibold text-white truncate text-sm drop-shadow-[0_1px_3px_rgba(0,0,0,0.6)]">{location.name}</h3>
           <div className="shrink-0">
             <StatusBadge status={location.status.site} />

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -1,7 +1,10 @@
+"use client";
+
 import Link from "next/link";
 import type { PlaceIndexEntry, Coordinates, Constraints } from "@/lib/types";
 import { haversineDistanceKm, formatDistance } from "@/lib/useCurrentLocation";
 import { buildFitParagraph } from "@/lib/fit";
+import { useEdgeColor } from "@/lib/useEdgeColor";
 import TypeBadge from "./TypeBadge";
 import StatusBadge from "./StatusBadge";
 import CostIndicator from "./CostIndicator";
@@ -43,6 +46,8 @@ export default function LocationCard({
 
   const fitBlurb = buildFitParagraph(location.fit, activeConstraints ?? null);
   const hoursStatus = formatHoursStatus(location.openingHours);
+
+  const edgeColor = useEdgeColor(photo);
 
   const cardClassName = `block rounded-lg border overflow-hidden transition-all duration-100 active:scale-[0.98] active:shadow-none ${
     isHighlighted
@@ -101,16 +106,28 @@ export default function LocationCard({
   );
 
   const cardContent = photo ? (
-    // Full-bleed photo card — content-sized, image fills as background
+    // Full-bleed photo card — image offset right, edge-color gradient on left
     <div className="relative w-full">
       <Image
         src={photo}
         alt=""
         fill
-        className="object-cover brightness-90 saturate-[0.85]"
+        className="object-cover object-right brightness-90 saturate-[0.85]"
         sizes="(max-width: 768px) 100vw, 400px"
       />
-      <div className="absolute inset-0 bg-gradient-to-b from-black/10 via-black/20 via-40% to-black/70" />
+      {/* Left-to-right gradient using extracted edge color, falling back to dark */}
+      <div
+        className="absolute inset-0"
+        style={
+          edgeColor
+            ? {
+                background: `linear-gradient(to right, rgba(${edgeColor}, 0.95) 0%, rgba(${edgeColor}, 0.75) 35%, rgba(${edgeColor}, 0.25) 65%, transparent 100%)`,
+              }
+            : {
+                background: "linear-gradient(to right, rgba(0,0,0,0.75) 0%, rgba(0,0,0,0.45) 40%, transparent 100%)",
+              }
+        }
+      />
       <div className="relative p-3 pt-1.5">
         <div className="flex items-start justify-between gap-2 mb-1">
           <h3 className="font-semibold text-white truncate text-sm drop-shadow-[0_1px_3px_rgba(0,0,0,0.6)]">{location.name}</h3>

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -58,15 +58,15 @@ export default function LocationCard({
 
   // Shared bottom row: highlights / fit / tags
   const bottomRow = fitBlurb ? (
-    <p className={`text-sm mt-1.5 line-clamp-2 ${photo ? "text-white/90 drop-shadow-[0_1px_3px_rgba(0,0,0,0.6)]" : "text-emerald-700 dark:text-emerald-400"}`}>
+    <p className={`text-sm mt-1.5 line-clamp-2 ${photo ? "max-w-[65%] text-white/90 drop-shadow-[0_1px_3px_rgba(0,0,0,0.6)]" : "text-emerald-700 dark:text-emerald-400"}`}>
       {fitBlurb}
     </p>
   ) : location.highlights.length > 0 ? (
-    <p className={`text-sm mt-1.5 line-clamp-1 ${photo ? "text-white/80 drop-shadow-[0_1px_3px_rgba(0,0,0,0.6)]" : "text-gray-600 dark:text-gray-400"}`}>
+    <p className={`text-sm mt-1.5 line-clamp-1 ${photo ? "max-w-[65%] text-white/80 drop-shadow-[0_1px_3px_rgba(0,0,0,0.6)]" : "text-gray-600 dark:text-gray-400"}`}>
       {location.highlights[0]}
     </p>
   ) : location.tags.length > 0 ? (
-    <div className="flex flex-wrap gap-1 mt-2">
+    <div className={`flex flex-wrap gap-1 mt-2 ${photo ? "max-w-[65%]" : ""}`}>
       {location.tags.slice(0, 3).map((tag) => (
         <span
           key={tag}

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -50,74 +50,90 @@ export default function LocationCard({
       : "border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm hover:shadow-md"
   }`;
 
-  const cardContent = (
-    <>
-      {photo && (
-        <div className="relative w-full h-16">
-          <Image
-            src={photo}
-            alt=""
-            fill
-            className="object-cover brightness-90 saturate-[0.85]"
-            sizes="(max-width: 768px) 100vw, 400px"
-          />
-          <div className="absolute inset-0 bg-gradient-to-b from-black/15 via-black/10 via-50% to-black/60" />
-          <div className="absolute bottom-0 left-0 right-0 px-3 pb-1.5 flex items-end justify-between gap-2">
-            <h3 className="font-semibold text-white truncate text-sm drop-shadow-[0_1px_3px_rgba(0,0,0,0.6)]">{location.name}</h3>
-            <div className="shrink-0">
-              <StatusBadge status={location.status.site} />
-            </div>
-          </div>
-        </div>
+  // Shared bottom row: highlights / fit / tags
+  const bottomRow = fitBlurb ? (
+    <p className={`text-sm mt-1.5 line-clamp-2 ${photo ? "text-white/90 drop-shadow-[0_1px_2px_rgba(0,0,0,0.5)]" : "text-emerald-700 dark:text-emerald-400"}`}>
+      {fitBlurb}
+    </p>
+  ) : location.highlights.length > 0 ? (
+    <p className={`text-sm mt-1.5 line-clamp-1 ${photo ? "text-white/80 drop-shadow-[0_1px_2px_rgba(0,0,0,0.5)]" : "text-gray-600 dark:text-gray-400"}`}>
+      {location.highlights[0]}
+    </p>
+  ) : location.tags.length > 0 ? (
+    <div className="flex flex-wrap gap-1 mt-2">
+      {location.tags.slice(0, 3).map((tag) => (
+        <span
+          key={tag}
+          className={`px-1.5 py-0.5 text-xs rounded ${photo ? "bg-white/20 text-white backdrop-blur-sm" : "bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300"}`}
+        >
+          {tag}
+        </span>
+      ))}
+    </div>
+  ) : null;
+
+  // Meta row: type icon, country, distance, cost, hours, source
+  const metaRow = (
+    <div className={`flex items-center gap-2 ${photo ? "[&_span]:text-white/80 [&_span]:drop-shadow-[0_1px_2px_rgba(0,0,0,0.4)]" : ""}`}>
+      <TypeBadge type={location.type} showLabel={false} />
+      <span className={`text-sm ${photo ? "text-white/80 drop-shadow-[0_1px_2px_rgba(0,0,0,0.4)]" : "text-gray-500 dark:text-gray-400"}`}>{location.country}</span>
+      {distance && (
+        <span className={`text-xs font-medium ${photo ? "text-white/80 drop-shadow-[0_1px_2px_rgba(0,0,0,0.4)]" : "text-gray-500 dark:text-gray-400"}`}>{distance}</span>
       )}
-      <div className="p-3 pt-1.5">
-        {!photo && (
-          <div className="flex items-start justify-between gap-2 mb-1">
-            <h3 className="font-semibold text-gray-900 dark:text-gray-100 truncate">{location.name}</h3>
-            <div className="shrink-0">
-              <StatusBadge status={location.status.site} />
-            </div>
+      <CostIndicator cost={location.cost} />
+      {hoursStatus && (
+        <span
+          className={`text-xs font-medium px-1.5 py-0.5 rounded ${
+            photo
+              ? hoursStatus.open
+                ? "bg-emerald-500/30 text-white backdrop-blur-sm"
+                : "bg-black/20 text-white/70 backdrop-blur-sm"
+              : hoursStatus.open
+                ? "bg-emerald-50 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-300"
+                : "bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400"
+          }`}
+        >
+          {hoursStatus.label}
+        </span>
+      )}
+      {location.source && <SourceAttribution source={location.source} />}
+    </div>
+  );
+
+  const cardContent = photo ? (
+    // Full-bleed photo card
+    <div className="relative w-full h-32">
+      <Image
+        src={photo}
+        alt=""
+        fill
+        className="object-cover brightness-90 saturate-[0.85]"
+        sizes="(max-width: 768px) 100vw, 400px"
+      />
+      <div className="absolute inset-0 bg-gradient-to-b from-black/10 via-black/20 via-40% to-black/70" />
+      <div className="absolute inset-0 flex flex-col justify-end p-3 gap-0.5">
+        <div className="flex items-end justify-between gap-2">
+          <h3 className="font-semibold text-white truncate text-sm drop-shadow-[0_1px_3px_rgba(0,0,0,0.6)]">{location.name}</h3>
+          <div className="shrink-0">
+            <StatusBadge status={location.status.site} />
           </div>
-        )}
-        <div className="flex items-center gap-2">
-          <TypeBadge type={location.type} showLabel={false} />
-          <span className="text-sm text-gray-500 dark:text-gray-400">{location.country}</span>
-          {distance && (
-            <span className="text-xs text-gray-500 dark:text-gray-400 font-medium">{distance}</span>
-          )}
-          <CostIndicator cost={location.cost} />
-          {hoursStatus && (
-            <span
-              className={`text-xs font-medium px-1.5 py-0.5 rounded ${
-                hoursStatus.open
-                  ? "bg-emerald-50 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-300"
-                  : "bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400"
-              }`}
-            >
-              {hoursStatus.label}
-            </span>
-          )}
-          {location.source && <SourceAttribution source={location.source} />}
         </div>
-        {fitBlurb ? (
-          <p className="text-sm text-emerald-700 dark:text-emerald-400 mt-1.5 line-clamp-2">
-            {fitBlurb}
-          </p>
-        ) : location.highlights.length > 0 ? (
-          <p className="text-sm text-gray-600 dark:text-gray-400 mt-1.5 line-clamp-1">
-            {location.highlights[0]}
-          </p>
-        ) : location.tags.length > 0 ? (
-          <div className="flex flex-wrap gap-1 mt-2">
-            {location.tags.slice(0, 3).map((tag) => (
-              <span key={tag} className="px-1.5 py-0.5 text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 rounded">
-                {tag}
-              </span>
-            ))}
-          </div>
-        ) : null}
+        {metaRow}
+        {bottomRow}
       </div>
-    </>
+    </div>
+  ) : (
+    // No-photo fallback
+    <div className="p-3 pt-1.5">
+      <div className="flex items-start justify-between gap-2 mb-1">
+        <h3 className="font-semibold text-gray-900 dark:text-gray-100 truncate">{location.name}</h3>
+        <div className="shrink-0">
+          <StatusBadge status={location.status.site} />
+        </div>
+      </div>
+      {metaRow}
+      {bottomRow}
+    </div>
   );
 
   // When onCardClick is provided, render as button (mobile sheet mode)

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -105,7 +105,7 @@ export default function LocationCard({
   );
 
   const cardContent = photo ? (
-    // Full-bleed photo card — image anchored right, gradient fills left gap
+    // Full-bleed photo card with edge-color gradient on left
     <div
       className="relative w-full"
       style={
@@ -119,7 +119,7 @@ export default function LocationCard({
         src={photo}
         alt=""
         loading="lazy"
-        className="absolute right-0 top-0 h-full w-auto brightness-90 saturate-[0.85]"
+        className="absolute inset-0 w-full h-full object-cover brightness-90 saturate-[0.85]"
       />
       {/* Left-to-right gradient using extracted edge color, falling back to dark */}
       <div

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -112,8 +112,8 @@ export default function LocationCard({
         src={photo}
         alt=""
         fill
-        className="object-cover brightness-90 saturate-[0.85]"
-        style={{ objectPosition: "65% center" }}
+        className="brightness-90 saturate-[0.85]"
+        style={{ objectFit: "cover", objectPosition: "65% center" }}
         sizes="(max-width: 768px) 100vw, 400px"
       />
       {/* Left-to-right gradient using extracted edge color, falling back to dark */}

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -130,10 +130,10 @@ export default function LocationCard({
         style={
           edgeColor
             ? {
-                background: `linear-gradient(to right, rgba(${edgeColor}, 0.95) 0%, rgba(${edgeColor}, 0.75) 35%, rgba(${edgeColor}, 0.25) 65%, transparent 100%)`,
+                background: `linear-gradient(to right, rgba(${edgeColor}, 1) 10%, transparent 60%)`,
               }
             : {
-                background: "linear-gradient(to right, rgba(0,0,0,0.75) 0%, rgba(0,0,0,0.45) 40%, transparent 100%)",
+                background: "linear-gradient(to right, rgba(0,0,0,1) 10%, transparent 60%)",
               }
         }
       />

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -107,20 +107,23 @@ export default function LocationCard({
   const cardContent = photo ? (
     // Full-bleed photo card with edge-color gradient on left
     <div
-      className="relative w-full"
+      className="relative w-full overflow-hidden"
       style={
         edgeColor
           ? { backgroundColor: `rgb(${edgeColor})` }
           : { backgroundColor: "#000" }
       }
     >
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        src={photo}
-        alt=""
-        loading="lazy"
-        className="absolute inset-0 w-full h-full object-cover brightness-90 saturate-[0.85]"
-      />
+      {/* Oversized container shifts photo center rightward; card clips overflow */}
+      <div className="absolute top-0 h-full" style={{ width: "130%", left: "10%" }}>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={photo}
+          alt=""
+          loading="lazy"
+          className="w-full h-full object-cover brightness-90 saturate-[0.85]"
+        />
+      </div>
       {/* Left-to-right gradient using extracted edge color, falling back to dark */}
       <div
         className="absolute inset-0"

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -58,11 +58,11 @@ export default function LocationCard({
 
   // Shared bottom row: highlights / fit / tags
   const bottomRow = fitBlurb ? (
-    <p className={`text-sm mt-1.5 line-clamp-2 ${photo ? "max-w-[65%] text-white/90 drop-shadow-[0_1px_3px_rgba(0,0,0,0.6)]" : "text-emerald-700 dark:text-emerald-400"}`}>
+    <p className={`text-sm mt-1.5 ${photo ? "max-w-[65%] text-white/90 drop-shadow-[0_1px_3px_rgba(0,0,0,0.6)]" : "line-clamp-2 text-emerald-700 dark:text-emerald-400"}`}>
       {fitBlurb}
     </p>
   ) : location.highlights.length > 0 ? (
-    <p className={`text-sm mt-1.5 line-clamp-1 ${photo ? "max-w-[65%] text-white/80 drop-shadow-[0_1px_3px_rgba(0,0,0,0.6)]" : "text-gray-600 dark:text-gray-400"}`}>
+    <p className={`text-sm mt-1.5 ${photo ? "max-w-[65%] text-white/80 drop-shadow-[0_1px_3px_rgba(0,0,0,0.6)]" : "line-clamp-1 text-gray-600 dark:text-gray-400"}`}>
       {location.highlights[0]}
     </p>
   ) : location.tags.length > 0 ? (

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -105,16 +105,14 @@ export default function LocationCard({
   );
 
   const cardContent = photo ? (
-    // Full-bleed photo card — image offset right, edge-color gradient on left
+    // Full-bleed photo card with edge-color gradient on left
     <div className="relative w-full">
-      {/* Plain img for full control over object-position (unoptimized images anyway) */}
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
         src={photo}
         alt=""
         loading="lazy"
         className="absolute inset-0 w-full h-full object-cover brightness-90 saturate-[0.85]"
-        style={{ objectPosition: "65% center" }}
       />
       {/* Left-to-right gradient using extracted edge color, falling back to dark */}
       <div

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRef } from "react";
 import Link from "next/link";
 import type { PlaceIndexEntry, Coordinates, Constraints } from "@/lib/types";
 import { haversineDistanceKm, formatDistance } from "@/lib/useCurrentLocation";
@@ -43,10 +44,11 @@ export default function LocationCard({
 
   const photo = location.photo && !location.photo.includes("placeholder") ? location.photo : undefined;
 
+  const cardRef = useRef<HTMLElement>(null);
   const fitBlurb = buildFitParagraph(location.fit, activeConstraints ?? null);
   const hoursStatus = formatHoursStatus(location.openingHours);
 
-  const edgeColor = useEdgeColor(photo);
+  const edgeColor = useEdgeColor(photo, cardRef);
   // Always darken the edge color so white text is readable over the gradient
   const gradientColor = edgeColor ? darkenEdgeColor(edgeColor) : null;
 
@@ -168,6 +170,7 @@ export default function LocationCard({
   if (onCardClick) {
     return (
       <button
+        ref={cardRef as React.RefObject<HTMLButtonElement>}
         className={`${cardClassName} w-full text-left`}
         onClick={() => onCardClick(location.slug)}
         onMouseEnter={() => onHover?.(location.slug)}
@@ -181,6 +184,7 @@ export default function LocationCard({
   // Default: render as link (desktop sidebar)
   return (
     <Link
+      ref={cardRef as React.RefObject<HTMLAnchorElement>}
       href={`/location/${location.slug}`}
       className={cardClassName}
       onMouseEnter={() => onHover?.(location.slug)}

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -134,10 +134,10 @@ export default function LocationCard({
         style={
           gradientColor
             ? {
-                background: `linear-gradient(to right, rgb(${gradientColor}) 35%, transparent 80%)`,
+                background: `linear-gradient(to right, rgb(${gradientColor}) 25%, transparent 80%)`,
               }
             : {
-                background: "linear-gradient(to right, rgb(0,0,0) 35%, transparent 80%)",
+                background: "linear-gradient(to right, rgb(0,0,0) 25%, transparent 80%)",
               }
         }
       />

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -112,7 +112,8 @@ export default function LocationCard({
         src={photo}
         alt=""
         fill
-        className="object-cover object-right brightness-90 saturate-[0.85]"
+        className="object-cover brightness-90 saturate-[0.85]"
+        style={{ objectPosition: "65% center" }}
         sizes="(max-width: 768px) 100vw, 400px"
       />
       {/* Left-to-right gradient using extracted edge color, falling back to dark */}

--- a/src/lib/useEdgeColor.ts
+++ b/src/lib/useEdgeColor.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, type RefObject } from "react";
+import { useState, useEffect, useCallback, type RefObject } from "react";
 
 // Simple LRU-ish cache so repeated renders don't re-extract
 const cache = new Map<string, string>();
@@ -18,38 +18,25 @@ export function useEdgeColor(
   containerRef?: RefObject<HTMLElement | null>,
 ): string | null {
   const cached = src ? cache.get(src) ?? null : null;
-  const [color, setColor] = useState<string | null>(cached);
+  const [asyncColor, setAsyncColor] = useState<string | null>(null);
   const [visible, setVisible] = useState(!containerRef);
 
-  // Sync state when src changes and cache already has the value
-  useEffect(() => {
-    if (cached && cached !== color) setColor(cached);
-  }, [src, cached]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Return cache hit immediately, fall back to async state
-  const current = cached ?? color;
-
   // Observe visibility when a container ref is provided
-  useEffect(() => {
-    if (!containerRef) {
+  const observerCallback = useCallback(([entry]: IntersectionObserverEntry[]) => {
+    if (entry.isIntersecting) {
       setVisible(true);
-      return;
     }
+  }, []);
+
+  useEffect(() => {
+    if (!containerRef) return;
     const el = containerRef.current;
     if (!el) return;
 
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setVisible(true);
-          observer.disconnect();
-        }
-      },
-      { rootMargin: "200px" },
-    );
+    const observer = new IntersectionObserver(observerCallback, { rootMargin: "200px" });
     observer.observe(el);
     return () => observer.disconnect();
-  }, [containerRef]);
+  }, [containerRef, observerCallback]);
 
   useEffect(() => {
     if (!src || !visible || cache.has(src)) return;
@@ -65,7 +52,6 @@ export function useEdgeColor(
         const ctx = canvas.getContext("2d", { willReadFrequently: true });
         if (!ctx) return;
 
-        // Draw small for speed
         if (img.naturalHeight <= 0 || img.naturalWidth <= 0) return;
         const h = 40;
         const w = Math.round((img.naturalWidth / img.naturalHeight) * h);
@@ -100,7 +86,7 @@ export function useEdgeColor(
         }
         cache.set(src, result);
 
-        if (!cancelled) setColor(result);
+        if (!cancelled) setAsyncColor(result);
       } catch {
         // Tainted canvas (CORS) — leave color as null → fallback gradient
       }
@@ -116,7 +102,8 @@ export function useEdgeColor(
     };
   }, [src, visible]);
 
-  return current;
+  // Cache hit takes priority; async state is fallback for first load
+  return cached ?? asyncColor;
 }
 
 /**

--- a/src/lib/useEdgeColor.ts
+++ b/src/lib/useEdgeColor.ts
@@ -86,3 +86,15 @@ export function useEdgeColor(src: string | undefined): string | null {
 
   return current;
 }
+
+/**
+ * Darkens an "r, g, b" edge color so white text is always readable.
+ * Preserves hue/saturation but caps perceived brightness to maxLuminance.
+ */
+export function darkenEdgeColor(rgb: string, maxLuminance = 90): string {
+  const [r, g, b] = rgb.split(",").map(Number);
+  const lum = 0.299 * r + 0.587 * g + 0.114 * b;
+  if (lum <= maxLuminance) return rgb;
+  const scale = maxLuminance / lum;
+  return `${Math.round(r * scale)}, ${Math.round(g * scale)}, ${Math.round(b * scale)}`;
+}

--- a/src/lib/useEdgeColor.ts
+++ b/src/lib/useEdgeColor.ts
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+// Simple LRU-ish cache so repeated renders don't re-extract
+const cache = new Map<string, string>();
+const MAX_CACHE = 80;
+
+/**
+ * Extracts the average color from the left edge of an image.
+ * Returns an "r, g, b" string for use in rgba(), or null while loading / on failure.
+ */
+export function useEdgeColor(src: string | undefined): string | null {
+  // Read from cache synchronously — avoids calling setState in the effect body
+  const cached = src ? cache.get(src) ?? null : null;
+  const [color, setColor] = useState<string | null>(cached);
+
+  // Keep color in sync when src changes and we already have a cached value
+  const current = cached ?? color;
+  if (cached && cached !== color) {
+    setColor(cached);
+  }
+
+  useEffect(() => {
+    if (!src || cache.has(src)) return;
+
+    let cancelled = false;
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+
+    img.onload = () => {
+      if (cancelled) return;
+      try {
+        const canvas = document.createElement("canvas");
+        const ctx = canvas.getContext("2d", { willReadFrequently: true });
+        if (!ctx) return;
+
+        // Draw small for speed
+        const h = 40;
+        const w = Math.round((img.naturalWidth / img.naturalHeight) * h);
+        canvas.width = w;
+        canvas.height = h;
+        ctx.drawImage(img, 0, 0, w, h);
+
+        // Sample left 8% strip
+        const stripW = Math.max(1, Math.round(w * 0.08));
+        const data = ctx.getImageData(0, 0, stripW, h).data;
+
+        let r = 0,
+          g = 0,
+          b = 0;
+        const count = stripW * h;
+        for (let i = 0; i < data.length; i += 4) {
+          r += data[i];
+          g += data[i + 1];
+          b += data[i + 2];
+        }
+        r = Math.round(r / count);
+        g = Math.round(g / count);
+        b = Math.round(b / count);
+
+        const result = `${r}, ${g}, ${b}`;
+
+        // Evict oldest entries if cache is full
+        if (cache.size >= MAX_CACHE) {
+          const first = cache.keys().next().value;
+          if (first !== undefined) cache.delete(first);
+        }
+        cache.set(src, result);
+
+        if (!cancelled) setColor(result);
+      } catch {
+        // Tainted canvas (CORS) — leave color as null → fallback gradient
+      }
+    };
+
+    img.onerror = () => {
+      // Image failed to load — leave null
+    };
+
+    img.src = src;
+    return () => {
+      cancelled = true;
+    };
+  }, [src]);
+
+  return current;
+}

--- a/src/lib/useEdgeColor.ts
+++ b/src/lib/useEdgeColor.ts
@@ -17,16 +17,17 @@ export function useEdgeColor(
   src: string | undefined,
   containerRef?: RefObject<HTMLElement | null>,
 ): string | null {
-  // Read from cache synchronously — avoids calling setState in the effect body
   const cached = src ? cache.get(src) ?? null : null;
   const [color, setColor] = useState<string | null>(cached);
   const [visible, setVisible] = useState(!containerRef);
 
-  // Keep color in sync when src changes and we already have a cached value
+  // Sync state when src changes and cache already has the value
+  useEffect(() => {
+    if (cached && cached !== color) setColor(cached);
+  }, [src, cached]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Return cache hit immediately, fall back to async state
   const current = cached ?? color;
-  if (cached && cached !== color) {
-    setColor(cached);
-  }
 
   // Observe visibility when a container ref is provided
   useEffect(() => {
@@ -65,8 +66,10 @@ export function useEdgeColor(
         if (!ctx) return;
 
         // Draw small for speed
+        if (img.naturalHeight <= 0 || img.naturalWidth <= 0) return;
         const h = 40;
         const w = Math.round((img.naturalWidth / img.naturalHeight) * h);
+        if (!isFinite(w) || w <= 0 || w > 10000) return;
         canvas.width = w;
         canvas.height = h;
         ctx.drawImage(img, 0, 0, w, h);

--- a/src/lib/useEdgeColor.ts
+++ b/src/lib/useEdgeColor.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef, type RefObject } from "react";
 
 // Simple LRU-ish cache so repeated renders don't re-extract
 const cache = new Map<string, string>();
@@ -9,11 +9,18 @@ const MAX_CACHE = 80;
 /**
  * Extracts the average color from the left edge of an image.
  * Returns an "r, g, b" string for use in rgba(), or null while loading / on failure.
+ *
+ * Pass an optional ref to a container element — extraction is deferred until the
+ * element is within 200px of the viewport (IntersectionObserver with rootMargin).
  */
-export function useEdgeColor(src: string | undefined): string | null {
+export function useEdgeColor(
+  src: string | undefined,
+  containerRef?: RefObject<HTMLElement | null>,
+): string | null {
   // Read from cache synchronously — avoids calling setState in the effect body
   const cached = src ? cache.get(src) ?? null : null;
   const [color, setColor] = useState<string | null>(cached);
+  const [visible, setVisible] = useState(!containerRef);
 
   // Keep color in sync when src changes and we already have a cached value
   const current = cached ?? color;
@@ -21,8 +28,30 @@ export function useEdgeColor(src: string | undefined): string | null {
     setColor(cached);
   }
 
+  // Observe visibility when a container ref is provided
   useEffect(() => {
-    if (!src || cache.has(src)) return;
+    if (!containerRef) {
+      setVisible(true);
+      return;
+    }
+    const el = containerRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "200px" },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [containerRef]);
+
+  useEffect(() => {
+    if (!src || !visible || cache.has(src)) return;
 
     let cancelled = false;
     const img = new Image();
@@ -82,7 +111,7 @@ export function useEdgeColor(src: string | undefined): string | null {
     return () => {
       cancelled = true;
     };
-  }, [src]);
+  }, [src, visible]);
 
   return current;
 }

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,4 @@
 {
-  "status": "passed",
+  "status": "failed",
   "failedTests": []
 }


### PR DESCRIPTION
## Summary

Redesigns LocationCard so photos fill the entire card background with text overlaid on an intelligent edge-color gradient.

### Changes

- **Full-bleed photo cards** — photos fill the card with an oversized container (130% width, offset 10% right) so the photo's focal point shifts rightward
- **Edge-color gradient** — `useEdgeColor` hook samples the left 8% strip of each photo via canvas to extract the dominant color, then applies a left-to-right gradient (solid at 25% → transparent at 80%) that blends seamlessly into the photo
- **Always-dark gradient** — `darkenEdgeColor` caps perceived brightness (ITU-R BT.601) so white text is always readable, while preserving the photo's hue/saturation
- **Deferred extraction** — IntersectionObserver (200px rootMargin) ensures edge color extraction only starts when cards are near the viewport, preventing black fallback on lazy-loaded cards
- **Detail text width limit** — Bottom row text (fit blurb, highlights, tags) capped at 65% width on photo cards to reduce overlap with the photo area; text wraps instead of truncating

### Files changed

- `src/components/LocationCard.tsx` — Full-bleed photo layout with gradient overlay
- `src/lib/useEdgeColor.ts` — New hook for canvas-based edge color extraction + `darkenEdgeColor` utility
- `__tests__/setup-firebase-mock.ts` — IntersectionObserver mock for jsdom

Closes #17