### PR TITLE
feat: weather-aware preferences, scoring, and fit blurbs

### DIFF
--- a/__tests__/lib/constraints.test.ts
+++ b/__tests__/lib/constraints.test.ts
@@ -117,8 +117,8 @@ describe("applyConstraints", () => {
       cost: "$$",
     };
     const enrichments = {
-      "test-swim": { slug: "test-swim", forecast: [{ date: new Date().toISOString().slice(0, 10), precis: "Rain." }] },
-      "test-museum": { slug: "test-museum", forecast: [{ date: new Date().toISOString().slice(0, 10), precis: "Rain." }] },
+      "test-swim": { slug: "test-swim", forecast: [{ date: (() => { const d = new Date(); return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,"0")}-${String(d.getDate()).padStart(2,"0")}`; })(), precis: "Rain." }] },
+      "test-museum": { slug: "test-museum", forecast: [{ date: (() => { const d = new Date(); return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,"0")}-${String(d.getDate()).padStart(2,"0")}`; })(), precis: "Rain." }] },
     };
     const result = applyConstraints(
       [swim, museum],
@@ -139,8 +139,8 @@ describe("applyConstraints", () => {
       cost: "free",
     };
     const enrichments = {
-      "test-swim": { slug: "test-swim", forecast: [{ date: new Date().toISOString().slice(0, 10), precis: "Sunny.", max: 35 }] },
-      "test-museum": { slug: "test-museum", forecast: [{ date: new Date().toISOString().slice(0, 10), precis: "Sunny.", max: 35 }] },
+      "test-swim": { slug: "test-swim", forecast: [{ date: (() => { const d = new Date(); return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,"0")}-${String(d.getDate()).padStart(2,"0")}`; })(), precis: "Sunny.", max: 35 }] },
+      "test-museum": { slug: "test-museum", forecast: [{ date: (() => { const d = new Date(); return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,"0")}-${String(d.getDate()).padStart(2,"0")}`; })(), precis: "Sunny.", max: 35 }] },
     };
     const result = applyConstraints(
       [museum, swim],

--- a/__tests__/lib/constraints.test.ts
+++ b/__tests__/lib/constraints.test.ts
@@ -7,10 +7,12 @@ import { DEFAULT_PRIORITY } from "../../src/lib/types";
 const noConstraints: Constraints = {
   distance: "any",
   date: null,
+  timeOfDay: null,
   cost: "any",
   duration: "any",
   group: null,
   visited: "any",
+  setting: "any",
   priority: [...DEFAULT_PRIORITY],
 };
 
@@ -104,5 +106,65 @@ describe("applyConstraints", () => {
     );
     expect(result[0].slug).toBe("far-place");
     expect(result[1].slug).toBe("near-place");
+  });
+
+  it("boosts indoor places with weather enrichment on rainy days", () => {
+    const museum: PlaceIndexEntry = {
+      ...swim,
+      slug: "test-museum",
+      name: "Test Museum",
+      type: "museum",
+      cost: "$$",
+    };
+    const enrichments = {
+      "test-swim": { slug: "test-swim", forecast: [{ date: new Date().toISOString().slice(0, 10), precis: "Rain." }] },
+      "test-museum": { slug: "test-museum", forecast: [{ date: new Date().toISOString().slice(0, 10), precis: "Rain." }] },
+    };
+    const result = applyConstraints(
+      [swim, museum],
+      noConstraints,
+      userLocation,
+      enrichments,
+    );
+    // Museum (indoor) should score higher than swim (outdoor-water) on rainy day
+    expect(result[0].slug).toBe("test-museum");
+  });
+
+  it("boosts outdoor-water places on hot clear days", () => {
+    const museum: PlaceIndexEntry = {
+      ...swim,
+      slug: "test-museum",
+      name: "Test Museum",
+      type: "museum",
+      cost: "free",
+    };
+    const enrichments = {
+      "test-swim": { slug: "test-swim", forecast: [{ date: new Date().toISOString().slice(0, 10), precis: "Sunny.", max: 35 }] },
+      "test-museum": { slug: "test-museum", forecast: [{ date: new Date().toISOString().slice(0, 10), precis: "Sunny.", max: 35 }] },
+    };
+    const result = applyConstraints(
+      [museum, swim],
+      noConstraints,
+      userLocation,
+      enrichments,
+    );
+    // Swim (outdoor-water) should score higher on a hot clear day
+    expect(result[0].slug).toBe("test-swim");
+  });
+
+  it("setting preference boosts matching places", () => {
+    const museum: PlaceIndexEntry = {
+      ...swim,
+      slug: "test-museum",
+      name: "Test Museum",
+      type: "museum",
+      cost: "free",
+    };
+    const result = applyConstraints(
+      [swim, museum],
+      { ...noConstraints, setting: "indoor" },
+      userLocation,
+    );
+    expect(result[0].slug).toBe("test-museum");
   });
 });

--- a/__tests__/lib/weather.test.ts
+++ b/__tests__/lib/weather.test.ts
@@ -133,9 +133,8 @@ describe("weatherFitPhrase", () => {
     expect(weatherFitPhrase("indoor", rain)).toContain("indoors");
   });
 
-  it("returns setting fallback when no forecast", () => {
-    expect(weatherFitPhrase("outdoor", null)).toContain("outdoor");
-    expect(weatherFitPhrase("indoor", null)).toContain("indoor");
-    expect(weatherFitPhrase("outdoor-water", null)).toContain("water");
+  it("returns null for no forecast", () => {
+    expect(weatherFitPhrase("outdoor", null)).toBeNull();
+    expect(weatherFitPhrase("indoor", null)).toBeNull();
   });
 });

--- a/__tests__/lib/weather.test.ts
+++ b/__tests__/lib/weather.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyWeather,
+  settingForPlace,
+  weatherScore,
+  weatherPhrase,
+  weatherFitPhrase,
+} from "../../src/lib/weather";
+import type { PlaceIndexEntry } from "../../src/lib/types";
+import type { DayForecast } from "../../src/lib/integrations/enrichment-types";
+
+const basePlaceEntry: PlaceIndexEntry = {
+  slug: "test",
+  name: "Test",
+  type: "swim",
+  coordinates: { lat: -37.8, lng: 144.9 },
+  region: "Victoria, Australia",
+  country: "AU",
+  cost: "free",
+  highlights: [],
+  status: { site: "open", lastVerified: "2026-01-01" },
+  tags: [],
+};
+
+describe("classifyWeather", () => {
+  it("classifies clear/sunny as clear", () => {
+    expect(classifyWeather("Sunny.")).toBe("clear");
+    expect(classifyWeather("Fine and warm.")).toBe("clear");
+  });
+
+  it("classifies rain keywords", () => {
+    expect(classifyWeather("Showers.")).toBe("rain");
+    expect(classifyWeather("Possible shower or two.")).toBe("rain");
+    expect(classifyWeather("Rain developing.")).toBe("rain");
+  });
+
+  it("classifies storms", () => {
+    expect(classifyWeather("Thunderstorm expected.")).toBe("storm");
+    expect(classifyWeather("Storm warning.")).toBe("storm");
+  });
+
+  it("classifies overcast", () => {
+    expect(classifyWeather("Mostly cloudy.")).toBe("overcast");
+    expect(classifyWeather("Overcast.")).toBe("overcast");
+    expect(classifyWeather("Fog patches.")).toBe("overcast");
+  });
+
+  it("returns clear for empty/undefined", () => {
+    expect(classifyWeather(undefined)).toBe("clear");
+    expect(classifyWeather("")).toBe("clear");
+  });
+});
+
+describe("settingForPlace", () => {
+  it("returns outdoor-water for swim/beach/pool types", () => {
+    expect(settingForPlace({ ...basePlaceEntry, type: "swim" })).toBe("outdoor-water");
+    expect(settingForPlace({ ...basePlaceEntry, type: "beach" })).toBe("outdoor-water");
+    expect(settingForPlace({ ...basePlaceEntry, type: "pool" })).toBe("outdoor-water");
+  });
+
+  it("returns outdoor for playground/walk types", () => {
+    expect(settingForPlace({ ...basePlaceEntry, type: "playground" })).toBe("outdoor");
+    expect(settingForPlace({ ...basePlaceEntry, type: "walk" })).toBe("outdoor");
+    expect(settingForPlace({ ...basePlaceEntry, type: "bushwalk" })).toBe("outdoor");
+  });
+
+  it("returns indoor for museum/eatery/cave types", () => {
+    expect(settingForPlace({ ...basePlaceEntry, type: "museum" })).toBe("indoor");
+    expect(settingForPlace({ ...basePlaceEntry, type: "eatery" })).toBe("indoor");
+    expect(settingForPlace({ ...basePlaceEntry, type: "cave" })).toBe("indoor");
+  });
+
+  it("uses tags for event types", () => {
+    expect(settingForPlace({ ...basePlaceEntry, type: "event", tags: ["indoor"] })).toBe("indoor");
+    expect(settingForPlace({ ...basePlaceEntry, type: "event", tags: ["outdoor"] })).toBe("outdoor");
+    expect(settingForPlace({ ...basePlaceEntry, type: "event", tags: [] })).toBe("outdoor");
+  });
+});
+
+describe("weatherScore", () => {
+  it("returns positive score for outdoor on clear days", () => {
+    const forecast: DayForecast = { date: "2026-04-17", precis: "Sunny." };
+    expect(weatherScore("outdoor", forecast)).toBeGreaterThan(0);
+  });
+
+  it("returns negative score for outdoor-water on rainy days", () => {
+    const forecast: DayForecast = { date: "2026-04-17", precis: "Rain." };
+    expect(weatherScore("outdoor-water", forecast)).toBeLessThan(0);
+  });
+
+  it("returns positive score for indoor on rainy days", () => {
+    const forecast: DayForecast = { date: "2026-04-17", precis: "Showers." };
+    expect(weatherScore("indoor", forecast)).toBeGreaterThan(0);
+  });
+
+  it("boosts outdoor-water on hot clear days", () => {
+    const hot: DayForecast = { date: "2026-04-17", precis: "Sunny.", max: 35 };
+    const mild: DayForecast = { date: "2026-04-17", precis: "Sunny.", max: 22 };
+    expect(weatherScore("outdoor-water", hot)).toBeGreaterThan(weatherScore("outdoor-water", mild));
+  });
+
+  it("returns 0 when no forecast", () => {
+    expect(weatherScore("outdoor", null)).toBe(0);
+  });
+});
+
+describe("weatherPhrase", () => {
+  it("returns appropriate phrases", () => {
+    expect(weatherPhrase({ date: "2026-04-17", precis: "Rain." })).toBe("rain is on the way");
+    expect(weatherPhrase({ date: "2026-04-17", precis: "Thunderstorm." })).toBe("storms are forecast");
+    expect(weatherPhrase({ date: "2026-04-17", precis: "Sunny.", max: 35 })).toBe("it's going to be a scorcher");
+    expect(weatherPhrase({ date: "2026-04-17", precis: "Fine.", max: 25 })).toBe("the weather looks great");
+  });
+
+  it("returns null for no forecast", () => {
+    expect(weatherPhrase(null)).toBeNull();
+  });
+});
+
+describe("weatherFitPhrase", () => {
+  it("suggests indoor alternative on rainy outdoor days", () => {
+    const rain: DayForecast = { date: "2026-04-17", precis: "Rain." };
+    expect(weatherFitPhrase("outdoor", rain)).toContain("indoor alternative");
+  });
+
+  it("suggests perfect weather for water on hot days", () => {
+    const hot: DayForecast = { date: "2026-04-17", precis: "Sunny.", max: 32 };
+    expect(weatherFitPhrase("outdoor-water", hot)).toContain("water");
+  });
+
+  it("suggests heading indoors on rainy indoor days", () => {
+    const rain: DayForecast = { date: "2026-04-17", precis: "Showers." };
+    expect(weatherFitPhrase("indoor", rain)).toContain("indoors");
+  });
+
+  it("returns null for no forecast", () => {
+    expect(weatherFitPhrase("outdoor", null)).toBeNull();
+  });
+});

--- a/__tests__/lib/weather.test.ts
+++ b/__tests__/lib/weather.test.ts
@@ -133,7 +133,9 @@ describe("weatherFitPhrase", () => {
     expect(weatherFitPhrase("indoor", rain)).toContain("indoors");
   });
 
-  it("returns null for no forecast", () => {
-    expect(weatherFitPhrase("outdoor", null)).toBeNull();
+  it("returns setting fallback when no forecast", () => {
+    expect(weatherFitPhrase("outdoor", null)).toContain("outdoor");
+    expect(weatherFitPhrase("indoor", null)).toContain("indoor");
+    expect(weatherFitPhrase("outdoor-water", null)).toContain("water");
   });
 });

--- a/data/locations/beach/bridgewater-bay-blairgowrie.yaml
+++ b/data/locations/beach/bridgewater-bay-blairgowrie.yaml
@@ -76,3 +76,4 @@ fit:
     full-day: 'A solid beach session with time to explore the area afterwards.'
   group: 'Family-friendly beach with safe swimming for kids.'
   date: 'Peak season in summer, but lovely on mild days too.'
+  setting: 'Rock pools are best at low tide on a warm day.'

--- a/data/locations/beach/eastern-beach-geelong.yaml
+++ b/data/locations/beach/eastern-beach-geelong.yaml
@@ -85,3 +85,4 @@ fit:
     full-day: 'A solid beach session with time to explore the area afterwards.'
   group: 'Gentle waves and soft sand are perfect for little ones.'
   date: 'Peak season in summer, but lovely on mild days too.'
+  setting: 'Sheltered waters, but still an open beach — pick a calm day.'

--- a/data/locations/beach/half-moon-bay-black-rock.yaml
+++ b/data/locations/beach/half-moon-bay-black-rock.yaml
@@ -79,3 +79,4 @@ fit:
     full-day: 'A solid beach session with time to explore the area afterwards.'
   group: 'Gentle waves and soft sand are perfect for little ones.'
   date: 'Peak season in summer, but lovely on mild days too.'
+  setting: 'Sheltered waters, but still an open beach — pick a calm day.'

--- a/data/locations/beach/number-16-beach-rye.yaml
+++ b/data/locations/beach/number-16-beach-rye.yaml
@@ -80,3 +80,4 @@ fit:
     full-day: 'A solid beach session with time to explore the area afterwards.'
   group: 'Family-friendly beach with safe swimming for kids.'
   date: 'Peak season in summer, but lovely on mild days too.'
+  setting: 'Rock pools are best at low tide on a warm day.'

--- a/data/locations/beach/portsea-back-beach.yaml
+++ b/data/locations/beach/portsea-back-beach.yaml
@@ -79,3 +79,4 @@ fit:
     full-day: 'A solid beach session with time to explore the area afterwards.'
   group: 'Great for groups and families.'
   date: 'Peak season in summer, but lovely on mild days too.'
+  setting: 'Exposed surf beach — wind and swell matter here.'

--- a/data/locations/beach/sorrento-rock-pools.yaml
+++ b/data/locations/beach/sorrento-rock-pools.yaml
@@ -75,3 +75,4 @@ fit:
     full-day: 'A solid beach session with time to explore the area afterwards.'
   group: 'Gentle waves and soft sand are perfect for little ones.'
   date: 'Peak season in summer, but lovely on mild days too.'
+  setting: 'Sheltered waters, but still an open beach — pick a calm day.'

--- a/data/locations/beach/squeaky-beach.yaml
+++ b/data/locations/beach/squeaky-beach.yaml
@@ -78,3 +78,4 @@ fit:
     full-day: 'A solid beach session with time to explore the area afterwards.'
   group: 'Family-friendly beach with safe swimming for kids.'
   date: 'Peak season in summer, but lovely on mild days too.'
+  setting: 'Sheltered waters, but still an open beach — pick a calm day.'

--- a/data/locations/event/ahoy-williamstown.yaml
+++ b/data/locations/event/ahoy-williamstown.yaml
@@ -73,3 +73,4 @@ fit:
     full-day: 'Done by lunchtime — plenty of day left for another outing.'
   group: 'Interactive exhibits and activities kids will love.'
   date: 'An annual highlight — keep an eye out for this year''s dates.'
+  setting: 'An outdoor foreshore event — fingers crossed for sunshine.'

--- a/data/locations/event/balloon-story-south-wharf.yaml
+++ b/data/locations/event/balloon-story-south-wharf.yaml
@@ -74,3 +74,4 @@ fit:
     full-day: 'Only an hour or so — plan other stops around it.'
   group: 'Interactive exhibits and activities kids will love.'
   date: 'An annual highlight — keep an eye out for this year''s dates.'
+  setting: 'An indoor event — great for unpredictable Melbourne days.'

--- a/data/locations/event/dinos-at-the-zoo.yaml
+++ b/data/locations/event/dinos-at-the-zoo.yaml
@@ -75,3 +75,4 @@ fit:
     full-day: 'Done by lunchtime — plenty of day left for another outing.'
   group: 'Interactive exhibits and activities kids will love.'
   date: 'An annual highlight — keep an eye out for this year''s dates.'
+  setting: 'Mostly outdoors at the zoo — dress for the weather.'

--- a/data/locations/event/fever-candlelight-classical.yaml
+++ b/data/locations/event/fever-candlelight-classical.yaml
@@ -81,3 +81,4 @@ fit:
     full-day: 'Just an hour — plenty of evening left afterwards.'
   group: 'Best for older kids, teens, and adults who enjoy live music.'
   date: 'Multiple sessions Thu–Sat — easy to find a time that works.'
+  setting: 'Held indoors — weather is a non-issue.'

--- a/data/locations/event/fever-candlelight-kids.yaml
+++ b/data/locations/event/fever-candlelight-kids.yaml
@@ -82,3 +82,4 @@ fit:
     full-day: 'Just 45 minutes — a nice addition to a bigger day out.'
   group: 'Designed for families — toddlers through teens will love it.'
   date: 'Weekend mornings — check Fever for specific dates.'
+  setting: 'Held indoors — weather is a non-issue.'

--- a/data/locations/event/fever-candlelight-rock.yaml
+++ b/data/locations/event/fever-candlelight-rock.yaml
@@ -80,3 +80,4 @@ fit:
     full-day: 'Just an hour — plenty of evening left afterwards.'
   group: 'Best for teens and adults — an atmospheric night out.'
   date: 'Thu & Sat sessions — check Fever for specific dates.'
+  setting: 'Held indoors — weather is a non-issue.'

--- a/data/locations/event/fever-candlelight-taylor-swift.yaml
+++ b/data/locations/event/fever-candlelight-taylor-swift.yaml
@@ -81,3 +81,4 @@ fit:
     full-day: 'Just an hour — plenty of evening left afterwards.'
   group: 'Fun for Swifties of all ages — kids 6+ welcome.'
   date: 'Fri & Sat sessions — book early, these sell out.'
+  setting: 'Held indoors — weather is a non-issue.'

--- a/data/locations/event/hijinx-hotel.yaml
+++ b/data/locations/event/hijinx-hotel.yaml
@@ -74,3 +74,4 @@ fit:
     full-day: 'Only an hour or so — plan other stops around it.'
   group: 'Interactive exhibits and activities kids will love.'
   date: 'An annual highlight — keep an eye out for this year''s dates.'
+  setting: 'An indoor event — great for unpredictable Melbourne days.'

--- a/data/locations/event/melbourne-museum-school-holidays.yaml
+++ b/data/locations/event/melbourne-museum-school-holidays.yaml
@@ -78,3 +78,4 @@ fit:
     full-day: 'Done by lunchtime — plenty of day left for another outing.'
   group: 'Interactive exhibits and activities kids will love.'
   date: 'An annual highlight — keep an eye out for this year''s dates.'
+  setting: 'Inside a museum — weather won''t touch you.'

--- a/data/locations/event/moonlight-cinema.yaml
+++ b/data/locations/event/moonlight-cinema.yaml
@@ -76,3 +76,4 @@ fit:
     full-day: 'Only an hour or so — plan other stops around it.'
   group: 'Interactive exhibits and activities kids will love.'
   date: 'Runs for a limited season — check dates before you go.'
+  setting: 'Outdoor cinema — clear skies are essential.'

--- a/data/locations/event/ngv-kids-lets-party.yaml
+++ b/data/locations/event/ngv-kids-lets-party.yaml
@@ -81,3 +81,4 @@ fit:
     full-day: 'Done by lunchtime — plenty of day left for another outing.'
   group: 'Interactive exhibits and activities kids will love.'
   date: 'Runs for a limited season — check dates before you go.'
+  setting: 'All under cover — no weather worries here.'

--- a/data/locations/event/play-school-acmi.yaml
+++ b/data/locations/event/play-school-acmi.yaml
@@ -77,3 +77,4 @@ fit:
     full-day: 'Only an hour or so — plan other stops around it.'
   group: 'Interactive exhibits and activities kids will love.'
   date: 'An annual highlight — keep an eye out for this year''s dates.'
+  setting: 'Fully indoors, so weather won''t be an issue.'

--- a/data/locations/event/queen-vic-night-market.yaml
+++ b/data/locations/event/queen-vic-night-market.yaml
@@ -75,3 +75,4 @@ fit:
     full-day: 'Only an hour or so — plan other stops around it.'
   group: 'Interactive exhibits and activities kids will love.'
   date: 'Runs on weds — check ahead to plan your visit.'
+  setting: 'An outdoor market — rug up in winter, enjoy in summer.'

--- a/data/locations/event/scienceworks-school-holidays.yaml
+++ b/data/locations/event/scienceworks-school-holidays.yaml
@@ -76,3 +76,4 @@ fit:
     full-day: 'Done by lunchtime — plenty of day left for another outing.'
   group: 'Interactive exhibits and activities kids will love.'
   date: 'An annual highlight — keep an eye out for this year''s dates.'
+  setting: 'An indoor event — great for unpredictable Melbourne days.'

--- a/data/locations/event/sealife-aquarium.yaml
+++ b/data/locations/event/sealife-aquarium.yaml
@@ -79,3 +79,4 @@ fit:
     full-day: 'Done by lunchtime — plenty of day left for another outing.'
   group: 'Interactive exhibits and activities kids will love.'
   date: 'An annual highlight — keep an eye out for this year''s dates.'
+  setting: 'Fully indoors — a perfect rainy-day activity.'

--- a/data/locations/museum/melbourne-holocaust-museum.yaml
+++ b/data/locations/museum/melbourne-holocaust-museum.yaml
@@ -71,3 +71,4 @@ fit:
     full-day: 'A morning visit leaves the afternoon free for something else.'
   group: 'Interactive displays keep younger visitors engaged.'
   date: 'Open regular hours — a great rainy-day option.'
+  setting: 'Fully inside — rain or shine, it''s always a good visit.'

--- a/data/locations/museum/rippon-lea-estate.yaml
+++ b/data/locations/museum/rippon-lea-estate.yaml
@@ -71,3 +71,4 @@ fit:
     full-day: 'A morning visit leaves the afternoon free for something else.'
   group: 'Interactive displays keep younger visitors engaged.'
   date: 'Open regular hours — a great rainy-day option.'
+  setting: 'Mostly indoors with outdoor gardens — partly weather-dependent.'

--- a/data/locations/playground/birrarung-marr-playground.yaml
+++ b/data/locations/playground/birrarung-marr-playground.yaml
@@ -61,3 +61,4 @@ fit:
     full-day: 'Great first stop — you''ll want a few more activities to fill the day.'
   group: 'Great for primary-aged kids who love to climb and explore.'
   date: 'Open every day — great for a morning or afternoon outing.'
+  setting: 'An outdoor playground — hat and sunscreen on sunny days.'

--- a/data/locations/playground/boulder-risk-play-park.yaml
+++ b/data/locations/playground/boulder-risk-play-park.yaml
@@ -63,3 +63,4 @@ fit:
     full-day: 'Great first stop — you''ll want a few more activities to fill the day.'
   group: 'Great for primary-aged kids who love to climb and explore.'
   date: 'Open every day — great for a morning or afternoon outing.'
+  setting: 'Outdoors with no cover — surfaces can be slippery when wet.'

--- a/data/locations/playground/carlton-gardens-playground.yaml
+++ b/data/locations/playground/carlton-gardens-playground.yaml
@@ -63,3 +63,4 @@ fit:
     full-day: 'Great first stop — you''ll want a few more activities to fill the day.'
   group: 'Great for primary-aged kids who love to climb and explore.'
   date: 'Open every day — great for a morning or afternoon outing.'
+  setting: 'An outdoor playground in the gardens — pack a hat.'

--- a/data/locations/playground/fitzroy-gardens-playground.yaml
+++ b/data/locations/playground/fitzroy-gardens-playground.yaml
@@ -64,3 +64,4 @@ fit:
     full-day: 'Great first stop — you''ll want a few more activities to fill the day.'
   group: 'Great for primary-aged kids who love to climb and explore.'
   date: 'Open every day — great for a morning or afternoon outing.'
+  setting: 'A nature playground — best enjoyed in dry weather.'

--- a/data/locations/playground/flagstaff-gardens-playground.yaml
+++ b/data/locations/playground/flagstaff-gardens-playground.yaml
@@ -61,3 +61,4 @@ fit:
     full-day: 'Great first stop — you''ll want a few more activities to fill the day.'
   group: 'Great for primary-aged kids who love to climb and explore.'
   date: 'Open every day — great for a morning or afternoon outing.'
+  setting: 'An outdoor playground in the gardens — pack a hat.'

--- a/data/locations/playground/ian-potter-childrens-garden.yaml
+++ b/data/locations/playground/ian-potter-childrens-garden.yaml
@@ -63,3 +63,4 @@ fit:
     full-day: 'Morning at the playground, afternoon exploring nearby.'
   group: 'Great for primary-aged kids who love to climb and explore.'
   date: 'Open every day — great for a morning or afternoon outing.'
+  setting: 'Water play — perfect on a hot day, skip it when it''s cold.'

--- a/data/locations/playground/lincoln-square-playground.yaml
+++ b/data/locations/playground/lincoln-square-playground.yaml
@@ -63,3 +63,4 @@ fit:
     full-day: 'Great first stop — you''ll want a few more activities to fill the day.'
   group: 'Great for primary-aged kids who love to climb and explore.'
   date: 'Open every day — great for a morning or afternoon outing.'
+  setting: 'An outdoor playground in the gardens — pack a hat.'

--- a/data/locations/playground/maritime-cove-park.yaml
+++ b/data/locations/playground/maritime-cove-park.yaml
@@ -60,3 +60,4 @@ fit:
     full-day: 'Great first stop — you''ll want a few more activities to fill the day.'
   group: 'Great for primary-aged kids who love to climb and explore.'
   date: 'Open every day — great for a morning or afternoon outing.'
+  setting: 'Water play — perfect on a hot day, skip it when it''s cold.'

--- a/data/locations/playground/ron-barassi-snr-park.yaml
+++ b/data/locations/playground/ron-barassi-snr-park.yaml
@@ -61,3 +61,4 @@ fit:
     full-day: 'Great first stop — you''ll want a few more activities to fill the day.'
   group: 'Great for primary-aged kids who love to climb and explore.'
   date: 'Open every day — great for a morning or afternoon outing.'
+  setting: 'Water play — perfect on a hot day, skip it when it''s cold.'

--- a/data/locations/playground/royal-park-nature-play.yaml
+++ b/data/locations/playground/royal-park-nature-play.yaml
@@ -63,3 +63,4 @@ fit:
     full-day: 'Great first stop — you''ll want a few more activities to fill the day.'
   group: 'Great for primary-aged kids who love to climb and explore.'
   date: 'Open every day — great for a morning or afternoon outing.'
+  setting: 'A nature playground — best enjoyed in dry weather.'

--- a/data/locations/swim/black-duck-hole.yaml
+++ b/data/locations/swim/black-duck-hole.yaml
@@ -64,3 +64,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'A summer essential — best on hot days.'
+  setting: 'Flowing water — currents change with the weather.'

--- a/data/locations/swim/blue-lake-plenty-gorge.yaml
+++ b/data/locations/swim/blue-lake-plenty-gorge.yaml
@@ -66,3 +66,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Best enjoyed on a warm, sunny day.'
+  setting: 'River swimming — check conditions after heavy rain.'

--- a/data/locations/swim/blue-rock-lake.yaml
+++ b/data/locations/swim/blue-rock-lake.yaml
@@ -66,3 +66,4 @@ fit:
     full-day: 'A half-day swim — explore the surrounds or nearby towns for the rest.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'A summer essential — best on hot days.'
+  setting: 'Open water in a reservoir — best on a calm, warm day.'

--- a/data/locations/swim/buchan-caves-reserve.yaml
+++ b/data/locations/swim/buchan-caves-reserve.yaml
@@ -67,3 +67,4 @@ fit:
     full-day: 'A half-day swim — explore the surrounds or nearby towns for the rest.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'A summer essential — best on hot days.'
+  setting: 'An open-water swim — save it for a warm, still day.'

--- a/data/locations/swim/colbrook-reservoir.yaml
+++ b/data/locations/swim/colbrook-reservoir.yaml
@@ -64,3 +64,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'Open water in a reservoir — best on a calm, warm day.'

--- a/data/locations/swim/cumberland-falls-lorne.yaml
+++ b/data/locations/swim/cumberland-falls-lorne.yaml
@@ -65,3 +65,4 @@ fit:
     full-day: 'A half-day swim — explore the surrounds or nearby towns for the rest.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'Waterfall pools — rain makes them dramatic but the current stronger.'

--- a/data/locations/swim/expedition-pass-reservoir.yaml
+++ b/data/locations/swim/expedition-pass-reservoir.yaml
@@ -65,3 +65,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'Open water in a reservoir — best on a calm, warm day.'

--- a/data/locations/swim/fairy-pools.yaml
+++ b/data/locations/swim/fairy-pools.yaml
@@ -59,3 +59,4 @@ fit:
     full-day: 'A half-day swim — explore the surrounds or nearby towns for the rest.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'A summer essential — best on hot days.'
+  setting: 'A waterfall swim — stunning after rain, but check conditions.'

--- a/data/locations/swim/green-hill-lake-ararat.yaml
+++ b/data/locations/swim/green-hill-lake-ararat.yaml
@@ -67,3 +67,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'Lake swimming — still water but open skies, weather matters.'

--- a/data/locations/swim/green-lake-horsham.yaml
+++ b/data/locations/swim/green-lake-horsham.yaml
@@ -67,3 +67,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'Lake swimming — still water but open skies, weather matters.'

--- a/data/locations/swim/hamilton-pool.yaml
+++ b/data/locations/swim/hamilton-pool.yaml
@@ -63,3 +63,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Best enjoyed on a warm, sunny day.'
+  setting: 'A waterfall swim — stunning after rain, but check conditions.'

--- a/data/locations/swim/jebbs-pool-lorne.yaml
+++ b/data/locations/swim/jebbs-pool-lorne.yaml
@@ -64,3 +64,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'A summer essential — best on hot days.'
+  setting: 'A riverside dip — save it for a sunny, settled day.'

--- a/data/locations/swim/lake-buffalo.yaml
+++ b/data/locations/swim/lake-buffalo.yaml
@@ -67,3 +67,4 @@ fit:
     full-day: 'A half-day swim — explore the surrounds or nearby towns for the rest.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'Open-water lake swim — best when it''s warm and calm.'

--- a/data/locations/swim/lake-catani.yaml
+++ b/data/locations/swim/lake-catani.yaml
@@ -70,3 +70,4 @@ fit:
     full-day: 'A half-day swim — explore the surrounds or nearby towns for the rest.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'A summer essential — best on hot days.'
+  setting: 'No shade on the water — sunscreen and a warm day are a must.'

--- a/data/locations/swim/lake-daylesford.yaml
+++ b/data/locations/swim/lake-daylesford.yaml
@@ -68,3 +68,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'Lakeside swimming — a sunny day makes all the difference.'

--- a/data/locations/swim/lake-esmond-ballarat.yaml
+++ b/data/locations/swim/lake-esmond-ballarat.yaml
@@ -67,3 +67,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'A summer essential — best on hot days.'
+  setting: 'Open-water lake swim — best when it''s warm and calm.'

--- a/data/locations/swim/lake-fyans.yaml
+++ b/data/locations/swim/lake-fyans.yaml
@@ -68,3 +68,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'Open-water lake swim — best when it''s warm and calm.'

--- a/data/locations/swim/lake-glenmaggie.yaml
+++ b/data/locations/swim/lake-glenmaggie.yaml
@@ -65,3 +65,4 @@ fit:
     full-day: 'A half-day swim — explore the surrounds or nearby towns for the rest.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'Lakeside swimming — a sunny day makes all the difference.'

--- a/data/locations/swim/lake-hume-jacksons-point.yaml
+++ b/data/locations/swim/lake-hume-jacksons-point.yaml
@@ -70,3 +70,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'A summer essential — best on hot days.'
+  setting: 'A riverside dip — save it for a sunny, settled day.'

--- a/data/locations/swim/lake-lonsdale.yaml
+++ b/data/locations/swim/lake-lonsdale.yaml
@@ -66,3 +66,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'Open-water lake swim — best when it''s warm and calm.'

--- a/data/locations/swim/lake-narracan.yaml
+++ b/data/locations/swim/lake-narracan.yaml
@@ -66,3 +66,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'A summer essential — best on hot days.'
+  setting: 'Open-water river spot — best on a warm day with low flow.'

--- a/data/locations/swim/lake-nillahcootie.yaml
+++ b/data/locations/swim/lake-nillahcootie.yaml
@@ -64,3 +64,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'No shade on the water — sunscreen and a warm day are a must.'

--- a/data/locations/swim/lake-sambell-beechworth.yaml
+++ b/data/locations/swim/lake-sambell-beechworth.yaml
@@ -64,3 +64,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'A summer essential — best on hot days.'
+  setting: 'Lake swimming — still water but open skies, weather matters.'

--- a/data/locations/swim/lake-william-hovell.yaml
+++ b/data/locations/swim/lake-william-hovell.yaml
@@ -65,3 +65,4 @@ fit:
     full-day: 'A half-day swim — explore the surrounds or nearby towns for the rest.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'A summer essential — best on hot days.'
+  setting: 'Flowing water — currents change with the weather.'

--- a/data/locations/swim/lerderderg-gorge.yaml
+++ b/data/locations/swim/lerderderg-gorge.yaml
@@ -71,3 +71,4 @@ fit:
     full-day: 'A half-day swim — explore the surrounds or nearby towns for the rest.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'A river swim — water level and flow depend on recent rain.'

--- a/data/locations/swim/lysterfield-lake.yaml
+++ b/data/locations/swim/lysterfield-lake.yaml
@@ -73,3 +73,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'Open-water lake swim — best when it''s warm and calm.'

--- a/data/locations/swim/macedon-reservoir.yaml
+++ b/data/locations/swim/macedon-reservoir.yaml
@@ -64,3 +64,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'A summer essential — best on hot days.'
+  setting: 'River swimming — check conditions after heavy rain.'

--- a/data/locations/swim/minnehaha-falls.yaml
+++ b/data/locations/swim/minnehaha-falls.yaml
@@ -66,3 +66,4 @@ fit:
     full-day: 'A half-day swim — explore the surrounds or nearby towns for the rest.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Best enjoyed on a warm, sunny day.'
+  setting: 'Falls swimming — the flow picks up after rain, so choose your day.'

--- a/data/locations/swim/niagara-falls.yaml
+++ b/data/locations/swim/niagara-falls.yaml
@@ -66,3 +66,4 @@ fit:
     full-day: 'A half-day swim — explore the surrounds or nearby towns for the rest.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'Falls swimming — the flow picks up after rain, so choose your day.'

--- a/data/locations/swim/ovens-river-nimmo-bridge.yaml
+++ b/data/locations/swim/ovens-river-nimmo-bridge.yaml
@@ -65,3 +65,4 @@ fit:
     full-day: 'A half-day swim — explore the surrounds or nearby towns for the rest.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'Open-water river spot — best on a warm day with low flow.'

--- a/data/locations/swim/ovens-river-porepunkah.yaml
+++ b/data/locations/swim/ovens-river-porepunkah.yaml
@@ -66,3 +66,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'A summer essential — best on hot days.'
+  setting: 'A riverside dip — save it for a sunny, settled day.'

--- a/data/locations/swim/ovens-river-wangaratta.yaml
+++ b/data/locations/swim/ovens-river-wangaratta.yaml
@@ -66,3 +66,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'A summer essential — best on hot days.'
+  setting: 'A river swim — water level and flow depend on recent rain.'

--- a/data/locations/swim/pykes-creek-reservoir.yaml
+++ b/data/locations/swim/pykes-creek-reservoir.yaml
@@ -65,3 +65,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'A river swim — water level and flow depend on recent rain.'

--- a/data/locations/swim/quarry-reserve-ferntree-gully.yaml
+++ b/data/locations/swim/quarry-reserve-ferntree-gully.yaml
@@ -67,3 +67,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'Lake swimming — still water but open skies, weather matters.'

--- a/data/locations/swim/river-murray-apex-beach-tocumwal.yaml
+++ b/data/locations/swim/river-murray-apex-beach-tocumwal.yaml
@@ -66,3 +66,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'Open-water river spot — best on a warm day with low flow.'

--- a/data/locations/swim/river-murray-thompsons-beach.yaml
+++ b/data/locations/swim/river-murray-thompsons-beach.yaml
@@ -66,3 +66,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'River swimming — check conditions after heavy rain.'

--- a/data/locations/swim/rocky-valley-reservoir.yaml
+++ b/data/locations/swim/rocky-valley-reservoir.yaml
@@ -66,3 +66,4 @@ fit:
     full-day: 'A half-day swim — explore the surrounds or nearby towns for the rest.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'A summer essential — best on hot days.'
+  setting: 'Open-water river spot — best on a warm day with low flow.'

--- a/data/locations/swim/shaws-lake-blackwood.yaml
+++ b/data/locations/swim/shaws-lake-blackwood.yaml
@@ -63,3 +63,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'A summer essential — best on hot days.'
+  setting: 'Open-water lake swim — best when it''s warm and calm.'

--- a/data/locations/swim/st-george-river-lorne.yaml
+++ b/data/locations/swim/st-george-river-lorne.yaml
@@ -64,3 +64,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'A summer essential — best on hot days.'
+  setting: 'River swimming — check conditions after heavy rain.'

--- a/data/locations/swim/st-georges-lake-creswick.yaml
+++ b/data/locations/swim/st-georges-lake-creswick.yaml
@@ -62,3 +62,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'A freshwater lake — gorgeous on a sunny day, skip it in rain.'

--- a/data/locations/swim/stratford-avon-river.yaml
+++ b/data/locations/swim/stratford-avon-river.yaml
@@ -65,3 +65,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'A summer essential — best on hot days.'
+  setting: 'A river swim — water level and flow depend on recent rain.'

--- a/data/locations/swim/tambo-river-ramrod-creek.yaml
+++ b/data/locations/swim/tambo-river-ramrod-creek.yaml
@@ -63,3 +63,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'A summer essential — best on hot days.'
+  setting: 'Flowing water — currents change with the weather.'

--- a/data/locations/swim/tambo-river-sardine-flat.yaml
+++ b/data/locations/swim/tambo-river-sardine-flat.yaml
@@ -64,3 +64,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'A summer essential — best on hot days.'
+  setting: 'A riverside dip — save it for a sunny, settled day.'

--- a/data/locations/swim/tarago-river-picnic-point.yaml
+++ b/data/locations/swim/tarago-river-picnic-point.yaml
@@ -66,3 +66,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'A summer essential — best on hot days.'
+  setting: 'Flowing water — currents change with the weather.'

--- a/data/locations/swim/taylors-lake-horsham.yaml
+++ b/data/locations/swim/taylors-lake-horsham.yaml
@@ -64,3 +64,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'Lake swimming — still water but open skies, weather matters.'

--- a/data/locations/swim/the-blowhole-hepburn-springs.yaml
+++ b/data/locations/swim/the-blowhole-hepburn-springs.yaml
@@ -69,3 +69,4 @@ fit:
     full-day: 'A half-day swim — explore the surrounds or nearby towns for the rest.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Best enjoyed on a warm, sunny day.'
+  setting: 'An open-water swim — weather and temperature set the vibe.'

--- a/data/locations/swim/the-pillars-mount-martha.yaml
+++ b/data/locations/swim/the-pillars-mount-martha.yaml
@@ -65,3 +65,4 @@ fit:
     full-day: 'A half-day swim — explore the surrounds or nearby towns for the rest.'
   group: 'A peaceful swim spot best suited to confident swimmers.'
   date: 'A summer essential — best on hot days.'
+  setting: 'An open-water swim spot — best enjoyed in good weather.'

--- a/data/locations/swim/tronoh-dredge-hole.yaml
+++ b/data/locations/swim/tronoh-dredge-hole.yaml
@@ -66,3 +66,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'Lake swimming — still water but open skies, weather matters.'

--- a/data/locations/swim/turpins-falls-kyneton.yaml
+++ b/data/locations/swim/turpins-falls-kyneton.yaml
@@ -65,3 +65,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'A waterfall swim — stunning after rain, but check conditions.'

--- a/data/locations/swim/vaughan-springs.yaml
+++ b/data/locations/swim/vaughan-springs.yaml
@@ -70,3 +70,4 @@ fit:
     full-day: 'A half-day swim — explore the surrounds or nearby towns for the rest.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'A river swim — water level and flow depend on recent rain.'

--- a/data/locations/swim/venus-baths-halls-gap.yaml
+++ b/data/locations/swim/venus-baths-halls-gap.yaml
@@ -68,3 +68,4 @@ fit:
     full-day: 'A half-day swim — explore the surrounds or nearby towns for the rest.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'A river swim — water level and flow depend on recent rain.'

--- a/data/locations/swim/werribee-gorge-needles-beach.yaml
+++ b/data/locations/swim/werribee-gorge-needles-beach.yaml
@@ -69,3 +69,4 @@ fit:
     full-day: 'A half-day swim — explore the surrounds or nearby towns for the rest.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'Ideal from spring through summer.'
+  setting: 'A river swim — water level and flow depend on recent rain.'

--- a/data/locations/swim/yarra-river-bend-of-islands.yaml
+++ b/data/locations/swim/yarra-river-bend-of-islands.yaml
@@ -62,3 +62,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'A summer essential — best on hot days.'
+  setting: 'A river swim — water level and flow depend on recent rain.'

--- a/data/locations/swim/yarra-river-laughing-waters.yaml
+++ b/data/locations/swim/yarra-river-laughing-waters.yaml
@@ -60,3 +60,4 @@ fit:
     full-day: 'A half-day swim — explore the surrounds or nearby towns for the rest.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'A summer essential — best on hot days.'
+  setting: 'Open-water river spot — best on a warm day with low flow.'

--- a/data/locations/swim/yarra-river-pound-bend.yaml
+++ b/data/locations/swim/yarra-river-pound-bend.yaml
@@ -62,3 +62,4 @@ fit:
     full-day: 'A half-day swim — explore the surrounds or nearby towns for the rest.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'A summer essential — best on hot days.'
+  setting: 'A river swim — water level and flow depend on recent rain.'

--- a/data/locations/swim/youngs-creek-reservoir.yaml
+++ b/data/locations/swim/youngs-creek-reservoir.yaml
@@ -63,3 +63,4 @@ fit:
     full-day: 'A quick dip — best combined with other nearby spots for a full day.'
   group: 'Shallow spots make it safe for little ones to splash around.'
   date: 'A summer essential — best on hot days.'
+  setting: 'No shade on the water — sunscreen and a warm day are a must.'

--- a/data/locations/walk/brighton-to-port-melbourne.yaml
+++ b/data/locations/walk/brighton-to-port-melbourne.yaml
@@ -95,3 +95,4 @@ fit:
     full-day: 'Finishes by midday — pair with a nearby café or swim spot.'
   group: 'Easy terrain that little legs can handle.'
   date: 'Spring wildflowers make this walk extra special.'
+  setting: 'Along the shore — wind and sun are constant companions.'

--- a/data/locations/walk/camberwell-to-st-kilda.yaml
+++ b/data/locations/walk/camberwell-to-st-kilda.yaml
@@ -69,3 +69,4 @@ fit:
     full-day: 'Finishes by midday — pair with a nearby café or swim spot.'
   group: 'An easy walk suitable for all fitness levels.'
   date: 'Spring wildflowers make this walk extra special.'
+  setting: 'An urban route — you can duck inside if it rains.'

--- a/data/locations/walk/darebin-creek-trail.yaml
+++ b/data/locations/walk/darebin-creek-trail.yaml
@@ -66,3 +66,4 @@ fit:
     full-day: 'Finishes by midday — pair with a nearby café or swim spot.'
   group: 'An easy walk suitable for all fitness levels.'
   date: 'Spring wildflowers make this walk extra special.'
+  setting: 'Along the water — pleasant in mild weather, muddy when wet.'

--- a/data/locations/walk/frankston-to-mt-eliza.yaml
+++ b/data/locations/walk/frankston-to-mt-eliza.yaml
@@ -68,3 +68,4 @@ fit:
     full-day: 'Finishes by midday — pair with a nearby café or swim spot.'
   group: 'A good walk for friends or couples.'
   date: 'Spring wildflowers make this walk extra special.'
+  setting: 'Along the shore — wind and sun are constant companions.'

--- a/data/locations/walk/inner-yarra-hike.yaml
+++ b/data/locations/walk/inner-yarra-hike.yaml
@@ -69,3 +69,4 @@ fit:
     full-day: 'A full-day trek with rewarding scenery throughout.'
   group: 'A good walk for friends or couples.'
   date: 'Spring wildflowers make this walk extra special.'
+  setting: 'Along the water — pleasant in mild weather, muddy when wet.'

--- a/data/locations/walk/merri-creek-walk.yaml
+++ b/data/locations/walk/merri-creek-walk.yaml
@@ -109,3 +109,4 @@ fit:
     full-day: 'Finishes by midday — pair with a nearby café or swim spot.'
   group: 'An easy walk suitable for all fitness levels.'
   date: 'Spring wildflowers make this walk extra special.'
+  setting: 'A creekside trail — shaded sections help on warm days.'

--- a/data/locations/walk/middle-yarra-templestowe.yaml
+++ b/data/locations/walk/middle-yarra-templestowe.yaml
@@ -67,3 +67,4 @@ fit:
     full-day: 'Finishes by midday — pair with a nearby café or swim spot.'
   group: 'A good walk for friends or couples.'
   date: 'Spring wildflowers make this walk extra special.'
+  setting: 'A creekside trail — shaded sections help on warm days.'

--- a/data/locations/walk/photographers-melbourne-walk.yaml
+++ b/data/locations/walk/photographers-melbourne-walk.yaml
@@ -72,3 +72,4 @@ fit:
     full-day: 'Finishes by midday — pair with a nearby café or swim spot.'
   group: 'An easy walk suitable for all fitness levels.'
   date: 'Spring wildflowers make this walk extra special.'
+  setting: 'Mostly paved and urban — walkable in most weather.'

--- a/data/locations/walk/port-phillip-bay-walk.yaml
+++ b/data/locations/walk/port-phillip-bay-walk.yaml
@@ -70,3 +70,4 @@ fit:
     full-day: 'Finishes by midday — pair with a nearby café or swim spot.'
   group: 'Easy terrain that little legs can handle.'
   date: 'Spring wildflowers make this walk extra special.'
+  setting: 'A coastal walk — exposed to sea breezes and weather.'

--- a/data/locations/walk/steves-great-parks-hike.yaml
+++ b/data/locations/walk/steves-great-parks-hike.yaml
@@ -70,3 +70,4 @@ fit:
     full-day: 'Finishes by midday — pair with a nearby café or swim spot.'
   group: 'An easy walk suitable for all fitness levels.'
   date: 'Spring wildflowers make this walk extra special.'
+  setting: 'An urban park walk — shade and shelter are never far away.'

--- a/data/locations/walk/western-waterways-hike.yaml
+++ b/data/locations/walk/western-waterways-hike.yaml
@@ -67,3 +67,4 @@ fit:
     full-day: 'A full-day trek with rewarding scenery throughout.'
   group: 'A good walk for friends or couples.'
   date: 'Spring wildflowers make this walk extra special.'
+  setting: 'A bushwalk — best in cool weather with no rain forecast.'

--- a/scripts/validate-locations.ts
+++ b/scripts/validate-locations.ts
@@ -154,7 +154,7 @@ function validateCoreFields(data: Record<string, unknown>): string[] {
       errors.push("fit: must be an object");
     } else {
       const fit = data.fit as Record<string, unknown>;
-      const validFitKeys = ["cost", "duration", "group", "date"];
+      const validFitKeys = ["cost", "duration", "group", "date", "setting"];
       const validDurationKeys = ["quick", "half-day", "full-day"];
       for (const key of Object.keys(fit)) {
         if (!validFitKeys.includes(key)) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -73,6 +73,10 @@ export default function HomePage() {
     if (!loaded.priority.includes("familiarity")) {
       loaded.priority = [...loaded.priority, "familiarity"];
     }
+    if (!loaded.priority.includes("setting")) {
+      loaded.priority = [...loaded.priority, "setting"];
+    }
+    if (!loaded.setting) loaded.setting = "any";
     return loaded;
   });
   const [highlightedSlug, setHighlightedSlug] = useState<string | null>(null);
@@ -246,6 +250,7 @@ export default function HomePage() {
               filters={filters}
               constraints={constraints}
               onClick={() => setPrefsOpen(true)}
+              enrichments={enrichments}
             />
           </div>
         </div>
@@ -274,6 +279,7 @@ export default function HomePage() {
                   filters={filters}
                   constraints={constraints}
                   onClick={() => setPrefsOpen(true)}
+                  enrichments={enrichments}
                 />
               </div>
               <FilterBar
@@ -294,6 +300,7 @@ export default function HomePage() {
                   userLocation={userLocation}
                   onCardClick={handleOpenDesktopDetail}
                   activeConstraints={constraints}
+                  enrichments={enrichments}
                 />
               </div>
             </>
@@ -370,6 +377,7 @@ export default function HomePage() {
               userLocation={userLocation}
               onCardClick={handleOpenDetail}
               activeConstraints={constraints}
+              enrichments={enrichments}
             />
           </>
         ) : null}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,6 +19,7 @@ import { DEFAULT_PRIORITY } from "@/lib/types";
 import type { ScoredPlace } from "@/lib/constraints";
 import { useUserData } from "@/lib/use-user-data";
 import { useExternalEvents } from "@/lib/integrations/use-external-events";
+import { useEnrichments } from "@/lib/integrations/use-enrichments";
 import { getLocationIndex } from "@/lib/locations";
 
 const LocationMap = dynamic(() => import("@/components/LocationMap"), {
@@ -44,6 +45,7 @@ const defaultConstraints: Constraints = {
   duration: "any",
   group: null,
   visited: "any",
+  setting: "any",
   priority: [...DEFAULT_PRIORITY],
 };
 
@@ -127,10 +129,12 @@ export default function HomePage() {
   // Merge in external events (from remote endpoint, if configured)
   const allLocations = useExternalEvents(staticLocations);
 
+  const enrichments = useEnrichments();
+
   const filteredLocations: ScoredPlace[] = useMemo(() => {
     const filtered = filterLocations(allLocations, filters);
-    return applyConstraints(filtered, constraints, userLocation);
-  }, [allLocations, filters, constraints, userLocation]);
+    return applyConstraints(filtered, constraints, userLocation, enrichments);
+  }, [allLocations, filters, constraints, userLocation, enrichments]);
 
   // Open detail view in the sheet (from pin tap or card tap)
   const handleOpenDetail = useCallback((slug: string) => {

--- a/src/components/FilterButton.tsx
+++ b/src/components/FilterButton.tsx
@@ -2,17 +2,28 @@
 
 import { SlidersHorizontal } from "lucide-react";
 import { generateSentence, activeFilterCount } from "@/lib/sentence";
+import { getForecastForPlace } from "@/lib/weather";
 import type { Filters, Constraints } from "@/lib/types";
+import type { EnrichmentIndex, DayForecast } from "@/lib/integrations/enrichment-types";
 
 interface FilterButtonProps {
   filters: Filters;
   constraints: Constraints;
   onClick: () => void;
+  enrichments?: EnrichmentIndex | null;
 }
 
-export default function FilterButton({ filters, constraints, onClick }: FilterButtonProps) {
+export default function FilterButton({ filters, constraints, onClick, enrichments }: FilterButtonProps) {
   const count = activeFilterCount(filters, constraints);
-  const sentence = generateSentence(filters, constraints);
+
+  // Pick a representative forecast (first enriched location) for the sentence preamble
+  let forecast: DayForecast | null = null;
+  if (enrichments) {
+    const firstSlug = Object.keys(enrichments).find((k) => enrichments[k]?.forecast?.length);
+    if (firstSlug) forecast = getForecastForPlace(firstSlug, enrichments);
+  }
+
+  const sentence = generateSentence(filters, constraints, forecast);
 
   return (
     <button

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import type { PlaceIndexEntry, Coordinates, Constraints } from "@/lib/types";
 import { haversineDistanceKm, formatDistance } from "@/lib/useCurrentLocation";
 import { buildFitParagraph } from "@/lib/fit";
+import type { EnrichmentIndex } from "@/lib/integrations/enrichment-types";
 import { useEdgeColor, darkenEdgeColor } from "@/lib/useEdgeColor";
 import TypeBadge from "./TypeBadge";
 import StatusBadge from "./StatusBadge";
@@ -19,6 +20,7 @@ interface LocationCardProps {
   userLocation?: Coordinates | null;
   onCardClick?: (slug: string) => void;
   activeConstraints?: Constraints | null;
+  enrichments?: EnrichmentIndex | null;
 }
 
 export default function LocationCard({
@@ -28,6 +30,7 @@ export default function LocationCard({
   userLocation,
   onCardClick,
   activeConstraints,
+  enrichments,
 }: LocationCardProps) {
   const driveMinutes = (location as { _driveMinutes?: number | null })._driveMinutes;
   const distance = driveMinutes != null
@@ -45,7 +48,7 @@ export default function LocationCard({
   const photo = location.photo && !location.photo.includes("placeholder") ? location.photo : undefined;
 
   const cardRef = useRef<HTMLElement>(null);
-  const fitBlurb = buildFitParagraph(location.fit, activeConstraints ?? null, location, null, driveMinutes);
+  const fitBlurb = buildFitParagraph(location.fit, activeConstraints ?? null, location, enrichments ?? null, driveMinutes);
   const hoursStatus = formatHoursStatus(location.openingHours);
 
   const edgeColor = useEdgeColor(photo, cardRef);

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -45,7 +45,7 @@ export default function LocationCard({
   const photo = location.photo && !location.photo.includes("placeholder") ? location.photo : undefined;
 
   const cardRef = useRef<HTMLElement>(null);
-  const fitBlurb = buildFitParagraph(location.fit, activeConstraints ?? null);
+  const fitBlurb = buildFitParagraph(location.fit, activeConstraints ?? null, location, null, driveMinutes);
   const hoursStatus = formatHoursStatus(location.openingHours);
 
   const edgeColor = useEdgeColor(photo, cardRef);

--- a/src/components/LocationDetailPanel.tsx
+++ b/src/components/LocationDetailPanel.tsx
@@ -358,7 +358,9 @@ export default function LocationDetailPanel({
 
       {/* Fit blurb — personalised editorial lead-in */}
       {(() => {
-        const fitText = buildFitParagraph(location.fit, activeConstraints ?? null);
+        const placeEntry = { slug: location.slug, name: location.name, type: location.type, coordinates: location.coordinates, region: location.region, country: location.country, cost: location.cost, highlights: location.highlights, status: location.status, tags: location.tags };
+        const driveMin = drivingInfo ? drivingInfo.duration / 60 : null;
+        const fitText = buildFitParagraph(location.fit, activeConstraints ?? null, placeEntry, enrichments, driveMin);
         if (!fitText) return null;
         const summary = location.highlights[0];
         const editorial = summary ? `${summary}. ${fitText}` : fitText;

--- a/src/components/LocationList.tsx
+++ b/src/components/LocationList.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import type { PlaceIndexEntry, Coordinates, Constraints } from "@/lib/types";
+import type { EnrichmentIndex } from "@/lib/integrations/enrichment-types";
 import LocationCard from "./LocationCard";
 
 interface LocationListProps {
@@ -9,6 +10,7 @@ interface LocationListProps {
   userLocation?: Coordinates | null;
   onCardClick?: (slug: string) => void;
   activeConstraints?: Constraints | null;
+  enrichments?: EnrichmentIndex | null;
 }
 
 export default function LocationList({
@@ -18,6 +20,7 @@ export default function LocationList({
   userLocation,
   onCardClick,
   activeConstraints,
+  enrichments,
 }: LocationListProps) {
   if (locations.length === 0) {
     return (
@@ -38,6 +41,7 @@ export default function LocationList({
           userLocation={userLocation}
           onCardClick={onCardClick}
           activeConstraints={activeConstraints}
+          enrichments={enrichments}
         />
       ))}
       <div className="pt-2 pb-1 text-center">

--- a/src/components/PreferencePanel.tsx
+++ b/src/components/PreferencePanel.tsx
@@ -11,6 +11,7 @@ import {
   X,
   ChevronDown,
   CircleCheck,
+  CloudSun,
 } from "lucide-react";
 import type {
   Filters,
@@ -22,6 +23,7 @@ import type {
   GroupType,
   DateMode,
   VisitedFilter,
+  SettingFilter,
 } from "@/lib/types";
 
 // ── Dimension metadata ──────────────────────────────────────
@@ -39,6 +41,7 @@ const DIMENSIONS: DimensionMeta[] = [
   { key: "duration", icon: Clock, label: "Duration" },
   { key: "group", icon: Users, label: "Who" },
   { key: "familiarity", icon: CircleCheck, label: "Familiarity" },
+  { key: "setting", icon: CloudSun, label: "Setting" },
 ];
 
 // ── Value options ───────────────────────────────────────────
@@ -76,6 +79,12 @@ const VISITED_OPTIONS: { value: VisitedFilter; label: string }[] = [
   { value: "familiar", label: "Somewhere familiar" },
 ];
 
+const SETTING_OPTIONS: { value: SettingFilter; label: string }[] = [
+  { value: "indoor", label: "Indoors" },
+  { value: "outdoor", label: "Outdoors" },
+  { value: "outdoor-water", label: "Water" },
+];
+
 // ── Helpers ─────────────────────────────────────────────────
 
 function getValueLabel(dim: FilterDimension, filters: Filters, constraints: Constraints): string {
@@ -110,6 +119,10 @@ function getValueLabel(dim: FilterDimension, filters: Filters, constraints: Cons
       return constraints.visited === "any"
         ? "Flexible"
         : VISITED_OPTIONS.find((o) => o.value === constraints.visited)?.label ?? "Flexible";
+    case "setting":
+      return constraints.setting === "any"
+        ? "Flexible"
+        : SETTING_OPTIONS.find((o) => o.value === constraints.setting)?.label ?? "Flexible";
   }
 }
 
@@ -121,6 +134,7 @@ function isActive(dim: FilterDimension, filters: Filters, constraints: Constrain
     case "duration": return constraints.duration !== "any";
     case "group": return constraints.group !== null;
     case "familiarity": return constraints.visited !== "any";
+    case "setting": return constraints.setting !== "any";
   }
 }
 
@@ -343,6 +357,24 @@ function ValuePicker({
               onClick={() => onConstraintsChange({ ...constraints, visited: constraints.visited === opt.value ? "any" : opt.value })}
               className={`px-2.5 py-1 text-xs rounded-full border transition-colors ${
                 constraints.visited === opt.value
+                  ? "bg-blue-600 text-white border-blue-600"
+                  : "border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:border-blue-300"
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      );
+    case "setting":
+      return (
+        <div className="flex flex-wrap gap-1.5">
+          {SETTING_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              onClick={() => onConstraintsChange({ ...constraints, setting: constraints.setting === opt.value ? "any" : opt.value })}
+              className={`px-2.5 py-1 text-xs rounded-full border transition-colors ${
+                constraints.setting === opt.value
                   ? "bg-blue-600 text-white border-blue-600"
                   : "border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:border-blue-300"
               }`}
@@ -592,6 +624,7 @@ export default function PreferencePanel({
       duration: "any",
       group: null,
       visited: "any",
+      setting: "any",
       priority: [...constraints.priority],
     });
   }, [filters, constraints, onFiltersChange, onConstraintsChange]);

--- a/src/components/SentenceFilter.tsx
+++ b/src/components/SentenceFilter.tsx
@@ -8,6 +8,7 @@ import type {
   DurationFilter,
   GroupType,
   VisitedFilter,
+  SettingFilter,
   DateMode,
   TimeOfDay,
   PlaceType,
@@ -113,6 +114,20 @@ const GROUP_OPTIONS: { value: GroupType; label: string }[] = [
 ];
 
 const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+const SETTING_LABELS: Record<SettingFilter, string> = {
+  indoor: "indoors",
+  outdoor: "outdoors",
+  "outdoor-water": "in the water",
+  any: "any setting",
+};
+
+const SETTING_OPTIONS: { value: SettingFilter; label: string }[] = [
+  { value: "any", label: "any setting" },
+  { value: "indoor", label: "indoors" },
+  { value: "outdoor", label: "outdoors" },
+  { value: "outdoor-water", label: "in the water" },
+];
 
 function dateToLabel(d: DateMode, tod: TimeOfDay): string {
   const todSuffix = tod === "day" ? ", daytime" : tod === "evening" ? ", evening" : "";
@@ -243,7 +258,7 @@ function OptionButton({
 
 // ── Main component ───────────────────────────────────────────
 
-type OpenToken = "type" | "distance" | "date" | "cost" | "duration" | "group" | "visited" | null;
+type OpenToken = "type" | "distance" | "date" | "cost" | "duration" | "group" | "visited" | "setting" | null;
 
 interface SentenceFilterProps {
   filters: Filters;
@@ -301,6 +316,7 @@ export default function SentenceFilter({
   const durActive = constraints.duration !== "any";
   const groupActive = constraints.group !== null;
   const visitedActive = constraints.visited !== "any";
+  const settingActive = constraints.setting !== "any";
 
   return (
     <div
@@ -595,6 +611,30 @@ export default function SentenceFilter({
               setOpenToken(null);
             }}
           />
+        </div>
+      </Token>
+
+      <span className="text-gray-400"> · </span>
+
+      {/* Setting token */}
+      <Token
+        label={SETTING_LABELS[constraints.setting]}
+        active={settingActive}
+        popoverOpen={openToken === "setting"}
+        onTap={() => toggle("setting")}
+      >
+        <div className="flex flex-col gap-0.5">
+          {SETTING_OPTIONS.map((opt) => (
+            <OptionButton
+              key={opt.value}
+              label={opt.label}
+              selected={constraints.setting === opt.value}
+              onClick={() => {
+                updateConstraint({ setting: opt.value });
+                setOpenToken(null);
+              }}
+            />
+          ))}
         </div>
       </Token>
     </div>

--- a/src/lib/constraints.ts
+++ b/src/lib/constraints.ts
@@ -213,7 +213,7 @@ export function applyConstraints(
       const setting = settingForPlace(place);
       const settingWeight = priorityWeights["setting"] ?? 1;
 
-      // Setting preference match (even without weather data)
+      // Setting preference match / mismatch
       if (constraints.setting !== "any") {
         if (setting === constraints.setting) {
           score += 10 * settingWeight;
@@ -222,6 +222,8 @@ export function applyConstraints(
           (constraints.setting === "outdoor-water" && setting === "outdoor")
         ) {
           score += 3 * settingWeight; // partial match
+        } else {
+          score -= 5 * settingWeight; // clear mismatch penalty
         }
       }
 

--- a/src/lib/constraints.ts
+++ b/src/lib/constraints.ts
@@ -1,7 +1,9 @@
 import type { PlaceIndexEntry, Constraints, Coordinates, DateMode, TimeOfDay } from "./types";
+import type { EnrichmentIndex } from "./integrations/enrichment-types";
 import { haversineDistanceKm } from "./useCurrentLocation";
 import { isEventOnDate, isEventOnDayOfWeek } from "./event-dates";
 import { getVisited } from "./visited";
+import { settingForPlace, getForecastForPlace, weatherScore } from "./weather";
 
 const ROAD_FACTOR = 1.4;
 const AVG_SPEED_KMH = 60;
@@ -138,6 +140,7 @@ export function applyConstraints(
   places: PlaceIndexEntry[],
   constraints: Constraints,
   userLocation: Coordinates | null,
+  enrichments?: EnrichmentIndex | null,
 ): ScoredPlace[] {
   const scored: ScoredPlace[] = [];
 
@@ -202,6 +205,31 @@ export function applyConstraints(
         score += 15 * familiarityWeight;
       } else if (constraints.visited === "familiar" && isVisited) {
         score += 15 * familiarityWeight;
+      }
+    }
+
+    // Weather × setting score
+    if (constraints.setting !== "any" || enrichments) {
+      const setting = settingForPlace(place);
+      const settingWeight = priorityWeights["setting"] ?? 1;
+
+      // Setting preference match (even without weather data)
+      if (constraints.setting !== "any") {
+        if (setting === constraints.setting) {
+          score += 10 * settingWeight;
+        } else if (
+          (constraints.setting === "outdoor" && setting === "outdoor-water") ||
+          (constraints.setting === "outdoor-water" && setting === "outdoor")
+        ) {
+          score += 3 * settingWeight; // partial match
+        }
+      }
+
+      // Weather-based adjustment
+      if (enrichments) {
+        const forecast = getForecastForPlace(place.slug, enrichments, driveMin ?? undefined);
+        const wScore = weatherScore(setting, forecast);
+        score += wScore * settingWeight;
       }
     }
 

--- a/src/lib/fit.ts
+++ b/src/lib/fit.ts
@@ -1,13 +1,19 @@
-import type { FitBlurbs, Constraints } from "./types";
+import type { FitBlurbs, Constraints, PlaceIndexEntry } from "./types";
+import type { EnrichmentIndex } from "./integrations/enrichment-types";
+import { settingForPlace, getForecastForPlace, weatherFitPhrase } from "./weather";
 
 /**
  * Build a short paragraph from the fit blurbs that match the user's
  * active preference dimensions (excluding distance & familiarity).
+ * Optionally appends a weather-aware observation.
  * Returns null if no blurbs match.
  */
 export function buildFitParagraph(
   fit: FitBlurbs | undefined,
   constraints: Constraints | null,
+  place?: PlaceIndexEntry | null,
+  enrichments?: EnrichmentIndex | null,
+  driveMinutes?: number | null,
 ): string | null {
   if (!fit || !constraints) return null;
 
@@ -26,6 +32,18 @@ export function buildFitParagraph(
 
   if (constraints.group && fit.group) parts.push(fit.group);
   if ((constraints.date || constraints.timeOfDay) && fit.date) parts.push(fit.date);
+
+  // Weather-aware fit phrase
+  if (place && enrichments) {
+    const setting = settingForPlace(place);
+    const forecast = getForecastForPlace(
+      place.slug,
+      enrichments,
+      driveMinutes ?? undefined,
+    );
+    const wp = weatherFitPhrase(setting, forecast);
+    if (wp) parts.push(wp);
+  }
 
   if (parts.length === 0) return null;
   return parts.join(" ");

--- a/src/lib/fit.ts
+++ b/src/lib/fit.ts
@@ -33,16 +33,23 @@ export function buildFitParagraph(
   if (constraints.group && fit.group) parts.push(fit.group);
   if ((constraints.date || constraints.timeOfDay) && fit.date) parts.push(fit.date);
 
-  // Weather-aware fit phrase
-  if (place && enrichments) {
+  // Setting blurb — show the YAML blurb when setting preference is active,
+  // or a weather-aware phrase when forecast data is available.
+  if (constraints.setting && constraints.setting !== "any" && fit.setting) {
+    parts.push(fit.setting);
+  }
+
+  if (place) {
     const setting = settingForPlace(place);
     const forecast = getForecastForPlace(
       place.slug,
-      enrichments,
+      enrichments ?? null,
       driveMinutes ?? undefined,
     );
-    const wp = weatherFitPhrase(setting, forecast);
-    if (wp) parts.push(wp);
+    if (forecast) {
+      const wp = weatherFitPhrase(setting, forecast);
+      if (wp) parts.push(wp);
+    }
   }
 
   if (parts.length === 0) return null;

--- a/src/lib/fit.ts
+++ b/src/lib/fit.ts
@@ -33,23 +33,23 @@ export function buildFitParagraph(
   if (constraints.group && fit.group) parts.push(fit.group);
   if ((constraints.date || constraints.timeOfDay) && fit.date) parts.push(fit.date);
 
-  // Setting blurb — show the YAML blurb when setting preference is active,
-  // or a weather-aware phrase when forecast data is available.
-  if (constraints.setting && constraints.setting !== "any" && fit.setting) {
-    parts.push(fit.setting);
-  }
-
-  if (place) {
+  // Setting blurb: prefer dynamic weather phrase when forecast is available,
+  // fall back to static YAML blurb otherwise.
+  if (place && enrichments) {
     const setting = settingForPlace(place);
     const forecast = getForecastForPlace(
       place.slug,
-      enrichments ?? null,
+      enrichments,
       driveMinutes ?? undefined,
     );
     if (forecast) {
       const wp = weatherFitPhrase(setting, forecast);
       if (wp) parts.push(wp);
+    } else if (constraints.setting && constraints.setting !== "any" && fit.setting) {
+      parts.push(fit.setting);
     }
+  } else if (constraints.setting && constraints.setting !== "any" && fit.setting) {
+    parts.push(fit.setting);
   }
 
   if (parts.length === 0) return null;

--- a/src/lib/sentence.ts
+++ b/src/lib/sentence.ts
@@ -1,6 +1,8 @@
 "use client";
 
 import type { Filters, Constraints, FilterDimension } from "@/lib/types";
+import type { DayForecast } from "@/lib/integrations/enrichment-types";
+import { classifyWeather, weatherPhrase } from "@/lib/weather";
 
 // ── Poetic idle sentences (no filters active) ────────────────
 
@@ -43,6 +45,12 @@ const VISITED_LEAD: Record<string, string> = {
   familiar: "An old favourite, waiting",
 };
 
+const SETTING_LEAD: Record<string, string> = {
+  indoor: "Under a roof, away from it all",
+  outdoor: "Out where the sky stretches wide",
+  "outdoor-water": "Where the water meets the shore",
+};
+
 // ── Trailing phrases (secondary position after em-dash) ──────
 
 const COST_TAIL: Record<string, string> = {
@@ -74,6 +82,19 @@ const GROUP_TAIL: Record<string, string> = {
 const VISITED_TAIL: Record<string, string> = {
   new: "somewhere new",
   familiar: "a place you know",
+};
+
+const SETTING_TAIL: Record<string, string> = {
+  indoor: "under cover",
+  outdoor: "in the open air",
+  "outdoor-water": "by the water",
+};
+
+// ── Weather preambles ────────────────────────────────────────
+
+const WEATHER_PREAMBLE: Record<string, string> = {
+  rain: "Rain is whispering outside",
+  storm: "A storm rolls in",
 };
 
 // ── Date / time helpers ──────────────────────────────────────
@@ -132,6 +153,7 @@ function getLeadPhrase(dim: FilterDimension, constraints: Constraints): string |
     case "duration": return DURATION_LEAD[constraints.duration] ?? null;
     case "group": return constraints.group ? (GROUP_LEAD[constraints.group] ?? null) : null;
     case "familiarity": return VISITED_LEAD[constraints.visited] ?? null;
+    case "setting": return constraints.setting !== "any" ? (SETTING_LEAD[constraints.setting] ?? null) : null;
     case "date": return getDateLeadPhrase(constraints.date, constraints.timeOfDay);
   }
 }
@@ -143,6 +165,7 @@ function getTailPhrase(dim: FilterDimension, constraints: Constraints): string |
     case "duration": return DURATION_TAIL[constraints.duration] ?? null;
     case "group": return constraints.group ? (GROUP_TAIL[constraints.group] ?? null) : null;
     case "familiarity": return VISITED_TAIL[constraints.visited] ?? null;
+    case "setting": return constraints.setting !== "any" ? (SETTING_TAIL[constraints.setting] ?? null) : null;
     case "date": return getDateTailPhrase(constraints.date, constraints.timeOfDay);
   }
 }
@@ -151,17 +174,18 @@ function getTailPhrase(dim: FilterDimension, constraints: Constraints): string |
  * Build a poetic, discovery-oriented sentence from the active filters.
  * The first active dimension (by priority) gets a full lead phrase;
  * remaining dimensions trail after an em-dash.
+ * Optionally incorporates weather context from BOM forecast data.
  *
  * Examples:
  *   No filters           → "Where shall the day take us?"
  *   cost=free            → "Let's wander where the price is nothing"
  *   cost+dist            → "Let's wander where the price is nothing — close at hand"
- *   group=family-young   → "Little legs and big ones, side by side"
- *   dist+group+duration  → "Adventure waits just around the bend — little ones in tow, just a stolen hour"
+ *   setting=indoor+rain  → "Rain is whispering outside — under a roof, away from it all"
  */
 export function generateSentence(
   filters: Filters,
   constraints: Constraints,
+  forecast?: DayForecast | null,
 ): string {
   const activeDims: FilterDimension[] = [];
   for (const dim of constraints.priority) {
@@ -170,7 +194,14 @@ export function generateSentence(
     }
   }
 
+  // Weather preamble for rain/storm — prepended before the main sentence
+  const condition = forecast ? classifyWeather(forecast.precis) : "clear";
+  const preamble = WEATHER_PREAMBLE[condition] ?? null;
+
   if (activeDims.length === 0) {
+    if (preamble) {
+      return `${preamble} — where shall we go?`;
+    }
     return IDLE_SENTENCES[new Date().getDay() % IDLE_SENTENCES.length];
   }
 
@@ -183,6 +214,9 @@ export function generateSentence(
   }
 
   if (!leadPhrase) {
+    if (preamble) {
+      return `${preamble} — where shall we go?`;
+    }
     return IDLE_SENTENCES[new Date().getDay() % IDLE_SENTENCES.length];
   }
 
@@ -191,11 +225,19 @@ export function generateSentence(
     .map((dim) => getTailPhrase(dim, constraints))
     .filter((p): p is string => p !== null);
 
+  // Compose: optionally preamble — lead — tails
+  let sentence: string;
   if (tailPhrases.length === 0) {
-    return leadPhrase;
+    sentence = leadPhrase;
+  } else {
+    sentence = `${leadPhrase} — ${tailPhrases.join(", ")}`;
   }
 
-  return `${leadPhrase} — ${tailPhrases.join(", ")}`;
+  if (preamble) {
+    return `${preamble} — ${sentence.charAt(0).toLowerCase() + sentence.slice(1)}`;
+  }
+
+  return sentence;
 }
 
 function isDimActive(dim: FilterDimension, filters: Filters, constraints: Constraints): boolean {
@@ -206,6 +248,7 @@ function isDimActive(dim: FilterDimension, filters: Filters, constraints: Constr
     case "duration": return constraints.duration !== "any";
     case "group": return constraints.group !== null;
     case "familiarity": return constraints.visited !== "any";
+    case "setting": return constraints.setting !== "any";
   }
 }
 
@@ -220,5 +263,6 @@ export function activeFilterCount(filters: Filters, constraints: Constraints): n
   if (constraints.duration !== "any") count++;
   if (constraints.group !== null) count++;
   if (constraints.visited !== "any") count++;
+  if (constraints.setting !== "any") count++;
   return count;
 }

--- a/src/lib/sentence.ts
+++ b/src/lib/sentence.ts
@@ -2,7 +2,7 @@
 
 import type { Filters, Constraints, FilterDimension } from "@/lib/types";
 import type { DayForecast } from "@/lib/integrations/enrichment-types";
-import { classifyWeather, weatherPhrase } from "@/lib/weather";
+import { classifyWeather } from "@/lib/weather";
 
 // ── Poetic idle sentences (no filters active) ────────────────
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,7 @@
+// ── Setting (venue environment) ──────────────────────────────
+
+export type Setting = "indoor" | "outdoor" | "outdoor-water";
+
 // ── Shared enums ──────────────────────────────────────────────
 
 export type PlaceType =
@@ -235,9 +239,11 @@ export type TimeOfDay = "day" | "evening" | null;
 
 export type VisitedFilter = "new" | "familiar" | "any";
 
-export type FilterDimension = "distance" | "date" | "cost" | "duration" | "group" | "familiarity";
+export type SettingFilter = "indoor" | "outdoor" | "outdoor-water" | "any";
 
-export const DEFAULT_PRIORITY: FilterDimension[] = ["distance", "date", "cost", "duration", "group", "familiarity"];
+export type FilterDimension = "distance" | "date" | "cost" | "duration" | "group" | "familiarity" | "setting";
+
+export const DEFAULT_PRIORITY: FilterDimension[] = ["distance", "date", "cost", "duration", "group", "familiarity", "setting"];
 
 export interface Constraints {
   distance: DistanceThreshold;
@@ -247,6 +253,7 @@ export interface Constraints {
   duration: DurationFilter;
   group: GroupType;
   visited: VisitedFilter;
+  setting: SettingFilter;
   priority: FilterDimension[];
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -136,6 +136,7 @@ export interface FitBlurbs {
   duration?: string | { quick?: string; "half-day"?: string; "full-day"?: string };
   group?: string;
   date?: string;
+  setting?: string;
 }
 
 // ── Discriminated union ───────────────────────────────────────

--- a/src/lib/weather.ts
+++ b/src/lib/weather.ts
@@ -170,31 +170,41 @@ export function weatherPhrase(forecast: DayForecast | null): string | null {
   }
 }
 
+/** Setting-only fallback blurbs (no forecast needed). */
+const SETTING_FALLBACK: Record<Setting, string> = {
+  indoor: "This is an indoor spot — great for any weather.",
+  outdoor: "This is an outdoor spot — check the forecast before heading out.",
+  "outdoor-water": "This is a water spot — best enjoyed on warm, sunny days.",
+};
+
 /** Setting-aware suggestion for the fit blurb. */
 export function weatherFitPhrase(
   setting: Setting,
   forecast: DayForecast | null,
 ): string | null {
-  if (!forecast) return null;
-  const condition = classifyWeather(forecast.precis);
+  // When we have a forecast, give a specific weather-aware blurb
+  if (forecast) {
+    const condition = classifyWeather(forecast.precis);
 
-  if (setting === "outdoor" || setting === "outdoor-water") {
-    if (condition === "rain" || condition === "storm") {
-      return "Weather today might not be ideal — consider an indoor alternative.";
+    if (setting === "outdoor" || setting === "outdoor-water") {
+      if (condition === "rain" || condition === "storm") {
+        return "Weather today might not be ideal — consider an indoor alternative.";
+      }
+      if (setting === "outdoor-water" && forecast.max !== undefined && forecast.max >= 30) {
+        return "Perfect weather for getting in the water!";
+      }
+      if (condition === "clear") {
+        return "Great weather for getting outside!";
+      }
     }
-    if (setting === "outdoor-water" && forecast.max !== undefined && forecast.max >= 30) {
-      return "Perfect weather for getting in the water!";
-    }
-    if (condition === "clear") {
-      return "Great weather for getting outside!";
+
+    if (setting === "indoor") {
+      if (condition === "rain" || condition === "storm") {
+        return "A perfect day to head indoors.";
+      }
     }
   }
 
-  if (setting === "indoor") {
-    if (condition === "rain" || condition === "storm") {
-      return "A perfect day to head indoors.";
-    }
-  }
-
-  return null;
+  // Fallback: always show a setting-based blurb
+  return SETTING_FALLBACK[setting] ?? null;
 }

--- a/src/lib/weather.ts
+++ b/src/lib/weather.ts
@@ -80,7 +80,8 @@ export function getForecastForPlace(
   const now = new Date();
   if (offsetMinutes) now.setMinutes(now.getMinutes() + offsetMinutes);
 
-  const targetDate = now.toISOString().slice(0, 10);
+  // Use local date string — BOM forecasts use Australian local dates
+  const targetDate = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
 
   return (
     enrichment.forecast.find((f) => f.date === targetDate) ??
@@ -181,6 +182,9 @@ export function weatherFitPhrase(
   if (setting === "outdoor" || setting === "outdoor-water") {
     if (condition === "rain" || condition === "storm") {
       return "Weather today might not be ideal — consider an indoor alternative.";
+    }
+    if (condition === "overcast") {
+      return "It's looking overcast — layers might be a good idea.";
     }
     if (setting === "outdoor-water" && forecast.max !== undefined && forecast.max >= 30) {
       return "Perfect weather for getting in the water!";

--- a/src/lib/weather.ts
+++ b/src/lib/weather.ts
@@ -170,41 +170,31 @@ export function weatherPhrase(forecast: DayForecast | null): string | null {
   }
 }
 
-/** Setting-only fallback blurbs (no forecast needed). */
-const SETTING_FALLBACK: Record<Setting, string> = {
-  indoor: "This is an indoor spot — great for any weather.",
-  outdoor: "This is an outdoor spot — check the forecast before heading out.",
-  "outdoor-water": "This is a water spot — best enjoyed on warm, sunny days.",
-};
-
-/** Setting-aware suggestion for the fit blurb. */
+/** Setting-aware suggestion for the fit blurb. Only returns a phrase when forecast data is available. */
 export function weatherFitPhrase(
   setting: Setting,
   forecast: DayForecast | null,
 ): string | null {
-  // When we have a forecast, give a specific weather-aware blurb
-  if (forecast) {
-    const condition = classifyWeather(forecast.precis);
+  if (!forecast) return null;
+  const condition = classifyWeather(forecast.precis);
 
-    if (setting === "outdoor" || setting === "outdoor-water") {
-      if (condition === "rain" || condition === "storm") {
-        return "Weather today might not be ideal — consider an indoor alternative.";
-      }
-      if (setting === "outdoor-water" && forecast.max !== undefined && forecast.max >= 30) {
-        return "Perfect weather for getting in the water!";
-      }
-      if (condition === "clear") {
-        return "Great weather for getting outside!";
-      }
+  if (setting === "outdoor" || setting === "outdoor-water") {
+    if (condition === "rain" || condition === "storm") {
+      return "Weather today might not be ideal — consider an indoor alternative.";
     }
-
-    if (setting === "indoor") {
-      if (condition === "rain" || condition === "storm") {
-        return "A perfect day to head indoors.";
-      }
+    if (setting === "outdoor-water" && forecast.max !== undefined && forecast.max >= 30) {
+      return "Perfect weather for getting in the water!";
+    }
+    if (condition === "clear") {
+      return "Great weather for getting outside!";
     }
   }
 
-  // Fallback: always show a setting-based blurb
-  return SETTING_FALLBACK[setting] ?? null;
+  if (setting === "indoor") {
+    if (condition === "rain" || condition === "storm") {
+      return "A perfect day to head indoors.";
+    }
+  }
+
+  return null;
 }

--- a/src/lib/weather.ts
+++ b/src/lib/weather.ts
@@ -1,0 +1,200 @@
+import type { PlaceType, Setting, PlaceIndexEntry } from "./types";
+import type { DayForecast, EnrichmentIndex } from "./integrations/enrichment-types";
+
+// ── Weather condition classification ────────────────────────
+
+export type WeatherCondition = "clear" | "overcast" | "rain" | "storm";
+
+/** Keywords in BOM precis that indicate each condition. */
+const RAIN_KEYWORDS = ["rain", "shower", "drizzle", "thunderstorm", "storm", "hail"];
+const OVERCAST_KEYWORDS = ["cloud", "overcast", "fog", "haze", "mist"];
+
+/**
+ * Classify a BOM precis string into a simplified weather condition.
+ * Falls back to "clear" when the precis is empty or unrecognised.
+ */
+export function classifyWeather(precis: string | undefined): WeatherCondition {
+  if (!precis) return "clear";
+  const lower = precis.toLowerCase();
+
+  if (RAIN_KEYWORDS.some((k) => lower.includes(k))) {
+    return lower.includes("storm") || lower.includes("thunder") ? "storm" : "rain";
+  }
+  if (OVERCAST_KEYWORDS.some((k) => lower.includes(k))) return "overcast";
+  return "clear";
+}
+
+// ── Setting derivation from place data ──────────────────────
+
+/** Default setting for each place type. */
+const TYPE_SETTING: Record<PlaceType, Setting> = {
+  swim: "outdoor-water",
+  beach: "outdoor-water",
+  pool: "outdoor-water",
+  waterfall: "outdoor-water",
+  fishing: "outdoor-water",
+  playground: "outdoor",
+  bushwalk: "outdoor",
+  walk: "outdoor",
+  lookout: "outdoor",
+  cycling: "outdoor",
+  wildlife: "outdoor",
+  cave: "indoor",
+  museum: "indoor",
+  eatery: "indoor",
+  event: "outdoor", // fallback; overridden by venueType if present
+};
+
+/**
+ * Derive the setting for a place from its type, tags, and event venueType.
+ */
+export function settingForPlace(place: PlaceIndexEntry): Setting {
+  // Events: use venueType from recurrence metadata if available
+  if (place.type === "event") {
+    // venueType is on the full Place details, but PlaceIndexEntry might
+    // carry it via tags. We check tags for explicit indoor/outdoor.
+    if (place.tags.includes("indoor")) return "indoor";
+    if (place.tags.includes("outdoor")) return "outdoor";
+    // Default for events is outdoor
+    return "outdoor";
+  }
+  return TYPE_SETTING[place.type] ?? "outdoor";
+}
+
+// ── Forecast lookup ─────────────────────────────────────────
+
+/**
+ * Get today's forecast for a place from the enrichment index.
+ * If `offsetMinutes` is provided, looks up the forecast for the
+ * date that many minutes from now (to account for drive time).
+ */
+export function getForecastForPlace(
+  slug: string,
+  enrichments: EnrichmentIndex | null,
+  offsetMinutes?: number,
+): DayForecast | null {
+  if (!enrichments) return null;
+  const enrichment = enrichments[slug];
+  if (!enrichment?.forecast?.length) return null;
+
+  const now = new Date();
+  if (offsetMinutes) now.setMinutes(now.getMinutes() + offsetMinutes);
+
+  const targetDate = now.toISOString().slice(0, 10);
+
+  return (
+    enrichment.forecast.find((f) => f.date === targetDate) ??
+    enrichment.forecast[0] ??
+    null
+  );
+}
+
+// ── Weather × setting scoring matrix ────────────────────────
+
+/**
+ * Score adjustment for weather × setting interaction.
+ * Positive = boost, negative = penalty.
+ */
+const WEATHER_SCORE: Record<Setting, Record<WeatherCondition, number>> = {
+  indoor: {
+    clear: 0,
+    overcast: 0,
+    rain: 5,    // indoor is a good pick on rainy days
+    storm: 8,
+  },
+  outdoor: {
+    clear: 5,
+    overcast: -3,
+    rain: -12,
+    storm: -18,
+  },
+  "outdoor-water": {
+    clear: 8,
+    overcast: -5,
+    rain: -15,
+    storm: -20,
+  },
+};
+
+/** Temperature bonus for outdoor-water on hot days, penalty on cold days. */
+function temperatureAdjustment(setting: Setting, maxTemp: number | undefined): number {
+  if (maxTemp === undefined) return 0;
+  if (setting === "outdoor-water") {
+    if (maxTemp >= 32) return 8;
+    if (maxTemp >= 28) return 5;
+    if (maxTemp < 18) return -8;
+    if (maxTemp < 22) return -4;
+    return 0;
+  }
+  if (setting === "outdoor") {
+    if (maxTemp >= 38) return -5;  // too hot for outdoor land activities
+    if (maxTemp >= 30) return 2;
+    if (maxTemp < 10) return -3;
+    return 0;
+  }
+  return 0;
+}
+
+export function weatherScore(
+  setting: Setting,
+  forecast: DayForecast | null,
+): number {
+  if (!forecast) return 0;
+  const condition = classifyWeather(forecast.precis);
+  const base = WEATHER_SCORE[setting][condition];
+  const temp = temperatureAdjustment(setting, forecast.max);
+  return base + temp;
+}
+
+// ── Weather description helpers ─────────────────────────────
+
+/** Short weather description for use in sentences. */
+export function weatherPhrase(forecast: DayForecast | null): string | null {
+  if (!forecast) return null;
+  const condition = classifyWeather(forecast.precis);
+  const temp = forecast.max;
+
+  switch (condition) {
+    case "storm":
+      return "storms are forecast";
+    case "rain":
+      return "rain is on the way";
+    case "overcast":
+      return "it's looking overcast";
+    case "clear": {
+      if (temp !== undefined && temp >= 32) return "it's going to be a scorcher";
+      if (temp !== undefined && temp >= 28) return "it's a warm one";
+      if (temp !== undefined && temp < 15) return "it's a chilly day";
+      return "the weather looks great";
+    }
+  }
+}
+
+/** Setting-aware suggestion for the fit blurb. */
+export function weatherFitPhrase(
+  setting: Setting,
+  forecast: DayForecast | null,
+): string | null {
+  if (!forecast) return null;
+  const condition = classifyWeather(forecast.precis);
+
+  if (setting === "outdoor" || setting === "outdoor-water") {
+    if (condition === "rain" || condition === "storm") {
+      return "Weather today might not be ideal — consider an indoor alternative.";
+    }
+    if (setting === "outdoor-water" && forecast.max !== undefined && forecast.max >= 30) {
+      return "Perfect weather for getting in the water!";
+    }
+    if (condition === "clear") {
+      return "Great weather for getting outside!";
+    }
+  }
+
+  if (setting === "indoor") {
+    if (condition === "rain" || condition === "storm") {
+      return "A perfect day to head indoors.";
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Implements #21 — adds a **Setting** preference dimension (indoor / outdoor / outdoor-water) with weather-aware scoring, sentence generation, and per-location fit blurbs.

### What's new

- **Setting preference** — new filter dimension in PreferencePanel and SentenceFilter (indoor / outdoor / outdoor-water)
- **Weather-aware constraint scoring** — BOM forecast data integrated into `applyConstraints` via a scoring matrix:
  - Indoor gets +5/+8 boost on rain/storm days
  - Outdoor penalised on rain (−12) and storm (−18), boosted on clear (+5)
  - Outdoor-water gets temperature bonuses (+8 for 32°C+) and cold penalties (−8 for <18°C)
  - Mismatch penalty (−5) when selected setting doesn't match a place
- **Poetic weather sentence preambles** — e.g. *"Rain is whispering outside — under a roof, away from it all"*
- **Per-location fit blurbs** — 101 YAML files updated with custom `setting:` blurbs in the `fit:` block
- **Dynamic weather fit phrases** — overlaid on cards/detail panels when BOM forecast data is available; YAML blurbs used as fallback
- **Enrichments wired to cards** — FilterButton, LocationList, and LocationCard all receive enrichment data for weather context

### Files changed

| Area | Files |
|------|-------|
| Core logic | `src/lib/weather.ts` (new), `types.ts`, `constraints.ts`, `sentence.ts`, `fit.ts` |
| UI | `PreferencePanel.tsx`, `SentenceFilter.tsx`, `FilterButton.tsx`, `LocationCard.tsx`, `LocationList.tsx`, `LocationDetailPanel.tsx` |
| Data | `page.tsx` (wiring), `validate-locations.ts`, 101 YAML files |
| Tests | `weather.test.ts` (new, 20 tests), `constraints.test.ts` (3 new tests) |

### Review issues addressed

- Fixed UTC date bug in forecast matching (uses local date now)
- Added sessionStorage migration for `setting` dimension
- Dynamic weather phrase takes priority over static YAML blurb (no contradictions)
- FilterButton now receives forecast for weather-aware sentence preamble
- Setting mismatch penalty (−5) ensures non-matching places rank lower

### Note

After merging, run `npm run deploy:data` to push the updated YAML data (new `setting:` blurbs) to Firestore.

Closes #21