### PR TITLE
UI: Relocate and enlarge FilterButton as map overlay on desktop

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,6 +13,13 @@ body {
   background: transparent;
 }
 
+/* Scale up the entire UI on desktop to ~110% */
+@media (min-width: 1024px) {
+  html {
+    font-size: 110%;
+  }
+}
+
 /* Leaflet container needs explicit height */
 .leaflet-container {
   height: 100%;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -233,10 +233,9 @@ export default function HomePage() {
             onMarkerHover={handleMarkerHover}
             onUserLocation={handleUserLocation}
           />
-          {/* Floating filter button — above the sheet on mobile, hidden on desktop */}
+          {/* Floating filter button — above the sheet on mobile, bottom-left on desktop */}
           <div
-            className="absolute left-3 z-20 lg:hidden transition-opacity"
-            style={{ bottom: "calc(var(--sheet-height, 96px) + 12px)" }}
+            className="absolute left-3 z-20 transition-opacity bottom-4 max-lg:[bottom:calc(var(--sheet-height,96px)+12px)]"
           >
             <FilterButton
               filters={filters}
@@ -265,13 +264,6 @@ export default function HomePage() {
             </>
           ) : (
             <>
-              <div className="p-3 border-b border-gray-200 dark:border-gray-700">
-                <FilterButton
-                  filters={filters}
-                  constraints={constraints}
-                  onClick={() => setPrefsOpen(true)}
-                />
-              </div>
               <FilterBar
                 filters={filters}
                 onChange={setFilters}

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -185,7 +185,7 @@ export default function FilterBar({
       )}
       <div
         ref={chipsRef}
-        className="flex items-center gap-2 px-3 py-1.5 overflow-x-auto scrollbar-hide md:flex-wrap md:overflow-x-visible"
+        className="flex items-center gap-2 px-3 py-2 overflow-x-auto scrollbar-hide md:flex-wrap md:overflow-x-visible"
         style={chipsStyle}
       >
         {orderedTypeChips.map((chip) => {

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -185,7 +185,7 @@ export default function FilterBar({
       )}
       <div
         ref={chipsRef}
-        className="flex items-center gap-2 px-3 py-2 overflow-x-auto scrollbar-hide md:flex-wrap md:overflow-x-visible"
+        className="flex items-center gap-2 px-3 py-1.5 overflow-x-auto scrollbar-hide md:flex-wrap md:overflow-x-visible"
         style={chipsStyle}
       >
         {orderedTypeChips.map((chip) => {

--- a/src/components/FilterButton.tsx
+++ b/src/components/FilterButton.tsx
@@ -29,7 +29,7 @@ export default function FilterButton({ filters, constraints, onClick }: FilterBu
           </span>
         )}
       </div>
-      <span className="text-sm lg:text-base text-gray-700 dark:text-gray-300 max-w-[300px] lg:max-w-[400px] text-left">
+      <span className="text-sm lg:text-base text-gray-700 dark:text-gray-300 max-w-[400px] lg:max-w-[520px] text-left">
         {sentence}
       </span>
     </button>

--- a/src/components/FilterButton.tsx
+++ b/src/components/FilterButton.tsx
@@ -17,11 +17,11 @@ export default function FilterButton({ filters, constraints, onClick }: FilterBu
   return (
     <button
       onClick={onClick}
-      className="flex items-center gap-2 backdrop-blur-md bg-white/85 dark:bg-gray-900/85
+      className="flex items-start gap-2 backdrop-blur-md bg-white/85 dark:bg-gray-900/85
                  rounded-2xl shadow-lg border border-white/60 dark:border-gray-700/60
                  px-3 py-2 lg:px-4 lg:py-2.5 transition-all hover:shadow-xl active:scale-[0.98]"
     >
-      <div className="relative">
+      <div className="relative mt-0.5">
         <SlidersHorizontal className="w-4 h-4 lg:w-5 lg:h-5 text-gray-600 dark:text-gray-300" />
         {count > 0 && (
           <span className="absolute -top-1.5 -right-1.5 w-3.5 h-3.5 lg:w-4 lg:h-4 bg-blue-600 text-white text-[9px] lg:text-[10px] font-bold rounded-full flex items-center justify-center">
@@ -29,7 +29,7 @@ export default function FilterButton({ filters, constraints, onClick }: FilterBu
           </span>
         )}
       </div>
-      <span className="text-sm lg:text-base text-gray-700 dark:text-gray-300 max-w-[240px] lg:max-w-[300px] truncate">
+      <span className="text-sm lg:text-base text-gray-700 dark:text-gray-300 max-w-[300px] lg:max-w-[400px] text-left">
         {sentence}
       </span>
     </button>

--- a/src/components/FilterButton.tsx
+++ b/src/components/FilterButton.tsx
@@ -19,17 +19,17 @@ export default function FilterButton({ filters, constraints, onClick }: FilterBu
       onClick={onClick}
       className="flex items-center gap-2 backdrop-blur-md bg-white/85 dark:bg-gray-900/85
                  rounded-2xl shadow-lg border border-white/60 dark:border-gray-700/60
-                 px-3 py-2 transition-all hover:shadow-xl active:scale-[0.98]"
+                 px-3 py-2 lg:px-4 lg:py-2.5 transition-all hover:shadow-xl active:scale-[0.98]"
     >
       <div className="relative">
-        <SlidersHorizontal className="w-4 h-4 text-gray-600 dark:text-gray-300" />
+        <SlidersHorizontal className="w-4 h-4 lg:w-5 lg:h-5 text-gray-600 dark:text-gray-300" />
         {count > 0 && (
-          <span className="absolute -top-1.5 -right-1.5 w-3.5 h-3.5 bg-blue-600 text-white text-[9px] font-bold rounded-full flex items-center justify-center">
+          <span className="absolute -top-1.5 -right-1.5 w-3.5 h-3.5 lg:w-4 lg:h-4 bg-blue-600 text-white text-[9px] lg:text-[10px] font-bold rounded-full flex items-center justify-center">
             {count}
           </span>
         )}
       </div>
-      <span className="text-sm text-gray-700 dark:text-gray-300 max-w-[240px] truncate">
+      <span className="text-sm lg:text-base text-gray-700 dark:text-gray-300 max-w-[240px] lg:max-w-[300px] truncate">
         {sentence}
       </span>
     </button>

--- a/src/components/FilterButton.tsx
+++ b/src/components/FilterButton.tsx
@@ -17,6 +17,8 @@ export default function FilterButton({ filters, constraints, onClick }: FilterBu
   return (
     <button
       onClick={onClick}
+      aria-label="Open filter preferences"
+      aria-haspopup="dialog"
       className="flex items-start gap-2 backdrop-blur-md bg-white/85 dark:bg-gray-900/85
                  rounded-2xl shadow-lg border border-white/60 dark:border-gray-700/60
                  px-3 py-2 lg:px-4 lg:py-2.5 transition-all hover:shadow-xl active:scale-[0.98]"
@@ -29,7 +31,7 @@ export default function FilterButton({ filters, constraints, onClick }: FilterBu
           </span>
         )}
       </div>
-      <span className="text-sm lg:text-base text-gray-700 dark:text-gray-300 max-w-[400px] lg:max-w-[520px] text-left">
+      <span className="text-sm lg:text-base text-gray-700 dark:text-gray-300 max-w-[25rem] lg:max-w-[32.5rem] text-left">
         {sentence}
       </span>
     </button>

--- a/src/components/PreferencePanel.tsx
+++ b/src/components/PreferencePanel.tsx
@@ -509,6 +509,7 @@ export default function PreferencePanel({
 
   const handlePanelDragStart = useCallback((e: React.PointerEvent) => {
     if (window.innerWidth < 1024) return;
+    if ((e.target as HTMLElement).closest("button")) return;
     e.preventDefault();
     const el = e.currentTarget;
     el.setPointerCapture(e.pointerId);

--- a/src/components/PreferencePanel.tsx
+++ b/src/components/PreferencePanel.tsx
@@ -503,6 +503,40 @@ export default function PreferencePanel({
   const containerRef = useRef<HTMLDivElement>(null);
   const cardRects = useRef<DOMRect[]>([]);
 
+  // Panel drag-to-move (desktop only)
+  const [panelOffset, setPanelOffset] = useState({ x: 0, y: 0 });
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const handlePanelDragStart = useCallback((e: React.PointerEvent) => {
+    if (window.innerWidth < 1024) return;
+    e.preventDefault();
+    const el = e.currentTarget;
+    el.setPointerCapture(e.pointerId);
+    let startX: number, startY: number;
+    setPanelOffset((cur) => {
+      startX = e.clientX - cur.x;
+      startY = e.clientY - cur.y;
+      return cur;
+    });
+
+    const onMove = (ev: React.PointerEvent | PointerEvent) => {
+      setPanelOffset({ x: ev.clientX - startX!, y: ev.clientY - startY! });
+    };
+    const onUp = () => {
+      el.removeEventListener("pointermove", onMove);
+      el.removeEventListener("pointerup", onUp);
+      el.removeEventListener("lostpointercapture", onUp);
+    };
+    el.addEventListener("pointermove", onMove);
+    el.addEventListener("pointerup", onUp);
+    el.addEventListener("lostpointercapture", onUp);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setPanelOffset({ x: 0, y: 0 });
+    onClose();
+  }, [onClose]);
+
   const priority = constraints.priority;
 
   const orderedDimensions = priority.map(
@@ -575,11 +609,11 @@ export default function PreferencePanel({
   useEffect(() => {
     if (!open) return;
     const handleEsc = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") handleClose();
     };
     document.addEventListener("keydown", handleEsc);
     return () => document.removeEventListener("keydown", handleEsc);
-  }, [open, onClose]);
+  }, [open, handleClose]);
 
     const activeCount = orderedDimensions.filter((d) => isActive(d.key, filters, constraints)).length;
 
@@ -601,12 +635,19 @@ export default function PreferencePanel({
   return (
     <div className="fixed inset-0 z-[1000] flex items-end lg:items-center lg:justify-center">
       {/* Backdrop */}
-      <div className="absolute inset-0 bg-black/30 dark:bg-black/50" onClick={onClose} />
+      <div className="absolute inset-0 bg-black/30 dark:bg-black/50" onClick={handleClose} />
 
       {/* Panel */}
-      <div className="relative w-full lg:w-[400px] max-h-[85vh] bg-white dark:bg-gray-900 rounded-t-2xl lg:rounded-2xl shadow-2xl flex flex-col overflow-hidden">
-        {/* Header */}
-        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100 dark:border-gray-800">
+      <div
+        ref={panelRef}
+        className="relative w-full lg:w-[400px] max-h-[85vh] bg-white dark:bg-gray-900 rounded-t-2xl lg:rounded-2xl shadow-2xl flex flex-col overflow-hidden"
+        style={panelOffset.x || panelOffset.y ? { transform: `translate(${panelOffset.x}px, ${panelOffset.y}px)` } : undefined}
+      >
+        {/* Header — drag handle on desktop */}
+        <div
+          onPointerDown={handlePanelDragStart}
+          className="flex items-center justify-between px-4 py-3 border-b border-gray-100 dark:border-gray-800 lg:cursor-grab lg:active:cursor-grabbing select-none"
+        >
           <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100">
             Preferences
           </h2>
@@ -619,7 +660,7 @@ export default function PreferencePanel({
                 Reset
               </button>
             )}
-            <button onClick={onClose} className="p-1 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg">
+            <button onClick={handleClose} className="p-1 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg">
               <X className="w-5 h-5 text-gray-500 dark:text-gray-400" />
             </button>
           </div>

--- a/src/components/PreferencePanel.tsx
+++ b/src/components/PreferencePanel.tsx
@@ -519,15 +519,15 @@ export default function PreferencePanel({
       return cur;
     });
 
-    const onMove = (ev: React.PointerEvent | PointerEvent) => {
+    const onMove = (ev: PointerEvent) => {
       setPanelOffset({ x: ev.clientX - startX!, y: ev.clientY - startY! });
     };
     const onUp = () => {
-      el.removeEventListener("pointermove", onMove);
+      el.removeEventListener("pointermove", onMove as EventListener);
       el.removeEventListener("pointerup", onUp);
       el.removeEventListener("lostpointercapture", onUp);
     };
-    el.addEventListener("pointermove", onMove);
+    el.addEventListener("pointermove", onMove as EventListener);
     el.addEventListener("pointerup", onUp);
     el.addEventListener("lostpointercapture", onUp);
   }, []);

--- a/src/components/PreferencePanel.tsx
+++ b/src/components/PreferencePanel.tsx
@@ -505,22 +505,20 @@ export default function PreferencePanel({
 
   // Panel drag-to-move (desktop only)
   const [panelOffset, setPanelOffset] = useState({ x: 0, y: 0 });
-  const panelRef = useRef<HTMLDivElement>(null);
+  const panelOffsetRef = useRef({ x: 0, y: 0 });
 
   const handlePanelDragStart = useCallback((e: React.PointerEvent) => {
     if (window.innerWidth < 1024) return;
     e.preventDefault();
     const el = e.currentTarget;
     el.setPointerCapture(e.pointerId);
-    let startX: number, startY: number;
-    setPanelOffset((cur) => {
-      startX = e.clientX - cur.x;
-      startY = e.clientY - cur.y;
-      return cur;
-    });
+    const startX = e.clientX - panelOffsetRef.current.x;
+    const startY = e.clientY - panelOffsetRef.current.y;
 
     const onMove = (ev: PointerEvent) => {
-      setPanelOffset({ x: ev.clientX - startX!, y: ev.clientY - startY! });
+      const next = { x: ev.clientX - startX, y: ev.clientY - startY };
+      panelOffsetRef.current = next;
+      setPanelOffset(next);
     };
     const onUp = () => {
       el.removeEventListener("pointermove", onMove as EventListener);
@@ -533,7 +531,9 @@ export default function PreferencePanel({
   }, []);
 
   const handleClose = useCallback(() => {
-    setPanelOffset({ x: 0, y: 0 });
+    const zero = { x: 0, y: 0 };
+    panelOffsetRef.current = zero;
+    setPanelOffset(zero);
     onClose();
   }, [onClose]);
 
@@ -639,14 +639,13 @@ export default function PreferencePanel({
 
       {/* Panel */}
       <div
-        ref={panelRef}
-        className="relative w-full lg:w-[400px] max-h-[85vh] bg-white dark:bg-gray-900 rounded-t-2xl lg:rounded-2xl shadow-2xl flex flex-col overflow-hidden"
+        className="relative w-full lg:w-[25rem] max-h-[85vh] bg-white dark:bg-gray-900 rounded-t-2xl lg:rounded-2xl shadow-2xl flex flex-col overflow-hidden"
         style={panelOffset.x || panelOffset.y ? { transform: `translate(${panelOffset.x}px, ${panelOffset.y}px)` } : undefined}
       >
         {/* Header — drag handle on desktop */}
         <div
           onPointerDown={handlePanelDragStart}
-          className="flex items-center justify-between px-4 py-3 border-b border-gray-100 dark:border-gray-800 lg:cursor-grab lg:active:cursor-grabbing select-none"
+          className="flex items-center justify-between px-4 py-3 border-b border-gray-100 dark:border-gray-800 lg:cursor-grab lg:active:cursor-grabbing lg:touch-none select-none"
         >
           <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100">
             Preferences


### PR DESCRIPTION
Closes #38

## Changes

### FilterButton as map overlay (desktop)
- Removed `lg:hidden` from the floating FilterButton — now visible on all breakpoints
- Positioned `bottom-4 left-3` on desktop, dynamic `calc(var(--sheet-height) + 12px)` on mobile via `max-lg:` variant
- Removed the FilterButton from the desktop sidebar header

### Enlarged FilterButton on desktop
- Icon: `w-5 h-5`, text: `text-base`, padding: `px-4 py-2.5`, badge: `w-4 h-4`
- Increased max-width to 400px (mobile) / 520px (desktop)
- Text wraps instead of truncating; icon aligns to top of text

### Draggable PreferencePanel on desktop
- Header bar acts as a drag handle on `lg+` screens (grab cursor)
- Uses pointer capture for smooth repositioning
- Position resets when panel closes; no change to mobile

### Desktop UI scale
- Sets `font-size: 110%` on root `html` at `lg+` breakpoint
- Tailwind rem units scale everything uniformly