### PR TITLE
Floating frosted-glass UI redesign (Issue #40)

### DIFF
--- a/certificates
+++ b/certificates
@@ -1,0 +1,1 @@
+/home/claude-svc/dripmap/certificates

--- a/public/generated
+++ b/public/generated
@@ -1,0 +1,1 @@
+/home/claude-svc/dripmap/public/generated

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,7 +4,7 @@
   "description": "Discover summer activities across Victoria",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#ffffff",
+  "background_color": "#aad3df",
   "theme_color": "#3b82f6",
   "icons": [
     {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,11 +6,29 @@
   --color-water-light: #dbeafe;
 }
 
+@layer base {
+  .scoop-left {
+    background: radial-gradient(circle at 100% 100%, transparent 20px, rgba(255,255,255,0.9) 20.5px);
+  }
+  .scoop-right {
+    background: radial-gradient(circle at 0 100%, transparent 20px, rgba(255,255,255,0.9) 20.5px);
+  }
+  @media (prefers-color-scheme: dark) {
+    .scoop-left {
+      background: radial-gradient(circle at 100% 100%, transparent 20px, rgba(17,24,39,0.9) 20.5px);
+    }
+    .scoop-right {
+      background: radial-gradient(circle at 0 100%, transparent 20px, rgba(17,24,39,0.9) 20.5px);
+    }
+  }
+}
+
 html,
 body {
   height: 100%;
   margin: 0;
-  background: transparent;
+  padding: 0;
+  overflow: hidden;
 }
 
 /* Scale up the entire UI on desktop to ~110% */
@@ -24,6 +42,20 @@ body {
 .leaflet-container {
   height: 100%;
   width: 100%;
+}
+
+/* Leaflet controls respect safe areas */
+.leaflet-control-container .leaflet-top {
+  padding-top: env(safe-area-inset-top, 0px) !important;
+}
+.leaflet-control-container .leaflet-right {
+  padding-right: env(safe-area-inset-right, 0px) !important;
+}
+.leaflet-control-container .leaflet-bottom {
+  padding-bottom: env(safe-area-inset-bottom, 0px) !important;
+}
+.leaflet-control-container .leaflet-left {
+  padding-left: env(safe-area-inset-left, 0px) !important;
 }
 
 /* Leaflet zoom controls */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,23 +6,6 @@
   --color-water-light: #dbeafe;
 }
 
-@layer base {
-  .scoop-left {
-    background: radial-gradient(circle at 100% 100%, transparent 20px, rgba(255,255,255,0.9) 20.5px);
-  }
-  .scoop-right {
-    background: radial-gradient(circle at 0 100%, transparent 20px, rgba(255,255,255,0.9) 20.5px);
-  }
-  @media (prefers-color-scheme: dark) {
-    .scoop-left {
-      background: radial-gradient(circle at 100% 100%, transparent 20px, rgba(17,24,39,0.9) 20.5px);
-    }
-    .scoop-right {
-      background: radial-gradient(circle at 0 100%, transparent 20px, rgba(17,24,39,0.9) 20.5px);
-    }
-  }
-}
-
 html,
 body {
   height: 100%;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -41,58 +41,9 @@ body {
   padding-left: env(safe-area-inset-left, 0px) !important;
 }
 
-/* Leaflet zoom controls */
+/* Leaflet zoom controls — hidden, using React buttons instead */
 .leaflet-control-zoom {
-  border: none !important;
-  border-radius: 12px !important;
-  overflow: hidden;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15) !important;
-}
-.leaflet-control-zoom a {
-  width: 36px !important;
-  height: 36px !important;
-  line-height: 36px !important;
-  font-size: 18px !important;
-  font-weight: 600 !important;
-  color: #334155 !important;
-  background: white !important;
-  border: none !important;
-  transition: background 0.15s ease, color 0.15s ease;
-}
-.leaflet-control-zoom a:hover {
-  background: #f1f5f9 !important;
-  color: #1e293b !important;
-}
-.leaflet-control-zoom a:active {
-  background: #e2e8f0 !important;
-}
-.leaflet-control-zoom-in {
-  border-bottom: 1px solid #e2e8f0 !important;
-  border-radius: 12px 12px 0 0 !important;
-}
-.leaflet-control-zoom-out {
-  border-radius: 0 0 12px 12px !important;
-}
-
-/* Leaflet zoom controls — dark mode */
-@media (prefers-color-scheme: dark) {
-  .leaflet-control-zoom {
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4) !important;
-  }
-  .leaflet-control-zoom a {
-    background: #1e293b !important;
-    color: #94a3b8 !important;
-  }
-  .leaflet-control-zoom a:hover {
-    background: #334155 !important;
-    color: #e2e8f0 !important;
-  }
-  .leaflet-control-zoom a:active {
-    background: #475569 !important;
-  }
-  .leaflet-control-zoom-in {
-    border-bottom-color: #334155 !important;
-  }
+  display: none !important;
 }
 
 /* Leaflet popups — dark mode */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -43,8 +43,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${merriweather.variable} dark:bg-gray-950`}>
-      <body className="h-full text-gray-900 dark:text-gray-100 dark:bg-gray-950 antialiased">
+    <html lang="en" className={`${merriweather.variable}`}>
+      <body className="h-full text-gray-900 dark:text-gray-100 antialiased">
         <Providers>
           {children}
         </Providers>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -220,9 +220,9 @@ export default function HomePage() {
     <div className="fixed inset-0 overflow-hidden">
       {/* Desktop layout: side-by-side */}
       <div className="h-full flex overflow-hidden">
-        {/* Map — leave room for collapsed bottom sheet on mobile */}
+        {/* Map — edge-to-edge, extends into safe areas */}
         <div className="flex-1 relative overflow-hidden">
-          {/* Faded logo overlay */}
+          {/* Faded logo overlay — respects safe area */}
           <div className="absolute left-3 right-3 z-10 flex items-center justify-between" style={{ top: "calc(0.75rem + env(safe-area-inset-top))" }}>
             <Link href="/" className="flex items-center gap-1.5 opacity-40">
               <Compass className="w-5 h-5 text-blue-600" />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -120,6 +120,8 @@ export default function HomePage() {
   const [snapTarget, setSnapTarget] = useState<number | null>(null);
   const [focusSheetHeight, setFocusSheetHeight] = useState<number | undefined>();
   const listScrollRef = useRef(0);
+  const desktopScrollRef = useRef<HTMLDivElement>(null);
+  const savedSheetHeightRef = useRef<number | null>(null);
 
   // Track dark mode for inline styles (radial-gradient can't use Tailwind dark:)
   const [isDark, setIsDark] = useState(false);
@@ -154,9 +156,11 @@ export default function HomePage() {
 
   // Open detail view in the sheet (from pin tap or card tap)
   const handleOpenDetail = useCallback((slug: string) => {
-    // Save list scroll position before switching to detail
-    const scrollEl = document.querySelector(".fixed.bottom-0 .overflow-y-auto");
+    // Save list scroll position and sheet height before switching to detail
+    const scrollEl = document.querySelector(".fixed.bottom-2 .overflow-y-auto") as HTMLElement | null;
     if (scrollEl) listScrollRef.current = scrollEl.scrollTop;
+    const sheetH = parseInt(getComputedStyle(document.documentElement).getPropertyValue("--sheet-height")) || null;
+    savedSheetHeightRef.current = sheetH;
 
     setDetailSlug(slug);
     setSheetView("detail");
@@ -171,14 +175,20 @@ export default function HomePage() {
     setDetailSlug(null);
     setHighlightedSlug(null);
     setFocusSheetHeight(undefined);
+    // Restore sheet to previous snap position
+    if (savedSheetHeightRef.current) {
+      setSnapTarget(savedSheetHeightRef.current);
+    }
     // Restore list scroll position after React re-renders the list
     requestAnimationFrame(() => {
-      const scrollEl = document.querySelector(".fixed.bottom-0 .overflow-y-auto");
+      const scrollEl = document.querySelector(".fixed.bottom-2 .overflow-y-auto") as HTMLElement | null;
       if (scrollEl) scrollEl.scrollTop = listScrollRef.current;
     });
   }, []);
 
   const handleOpenDesktopDetail = useCallback((slug: string) => {
+    // Save desktop list scroll position
+    if (desktopScrollRef.current) listScrollRef.current = desktopScrollRef.current.scrollTop;
     setDetailSlug(slug);
     setSheetView("detail");
   }, []);
@@ -187,6 +197,10 @@ export default function HomePage() {
     setSheetView("list");
     setDetailSlug(null);
     setHighlightedSlug(null);
+    // Restore desktop list scroll position after React re-renders
+    requestAnimationFrame(() => {
+      if (desktopScrollRef.current) desktopScrollRef.current.scrollTop = listScrollRef.current;
+    });
   }, []);
 
   const handleMarkerClick = useCallback((slug: string) => {
@@ -309,7 +323,7 @@ export default function HomePage() {
                 {/* Scooped/inverted corners — layered over scroll area, not inside it */}
                 <div className="hidden lg:block absolute left-0 w-5 h-5 pointer-events-none z-20" style={{ top: '-1px', background: `radial-gradient(circle at 100% 100%, transparent 20px, ${scoopColor} 20.5px)`, filter: 'drop-shadow(0 4px 12px rgba(0,0,0,0.12))' }} />
                 <div className="hidden lg:block absolute right-0 w-5 h-5 pointer-events-none z-20" style={{ top: '-1px', background: `radial-gradient(circle at 0% 100%, transparent 20px, ${scoopColor} 20.5px)`, filter: 'drop-shadow(0 4px 12px rgba(0,0,0,0.12))' }} />
-                <div className="h-full overflow-y-auto">
+                <div ref={desktopScrollRef} className="h-full overflow-y-auto">
                 {loadError && (
                   <div className="mx-3 mt-2 p-3 bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-700 dark:text-red-300">
                     Failed to load locations. Please try refreshing the page.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -121,6 +121,18 @@ export default function HomePage() {
   const [focusSheetHeight, setFocusSheetHeight] = useState<number | undefined>();
   const listScrollRef = useRef(0);
 
+  // Track dark mode for inline styles (radial-gradient can't use Tailwind dark:)
+  const [isDark, setIsDark] = useState(false);
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    setIsDark(mq.matches); // eslint-disable-line react-hooks/set-state-in-effect
+    const handler = (e: MediaQueryListEvent) => setIsDark(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+  const scoopColor = isDark ? 'rgba(17,24,39,0.95)' : 'rgba(255,255,255,0.95)';
+
   useEffect(() => {
     getLocationIndex()
       .then((data) => setStaticLocations(data))
@@ -279,11 +291,12 @@ export default function HomePage() {
                   onChange={setFilters}
                   resultCount={filteredLocations.length}
                 />
-                {/* Scooped/inverted corners — concave cutouts hanging from filter bar */}
-                <div className="scoop-left hidden lg:block absolute top-full left-0 w-5 h-5 pointer-events-none z-50" style={{ filter: 'drop-shadow(0 4px 12px rgba(0,0,0,0.12))' }} />
-                <div className="scoop-right hidden lg:block absolute top-full right-0 w-5 h-5 pointer-events-none z-50" style={{ filter: 'drop-shadow(0 4px 12px rgba(0,0,0,0.12))' }} />
               </div>
-              <div className="flex-1 overflow-y-auto shadow-[inset_0_-6px_12px_rgba(0,0,0,0.08)]">
+              <div className="relative flex-1 min-h-0 shadow-[inset_0_-6px_12px_rgba(0,0,0,0.08)]">
+                {/* Scooped/inverted corners — layered over scroll area, not inside it */}
+                <div className="hidden lg:block absolute left-0 w-5 h-5 pointer-events-none z-20" style={{ top: '-1px', background: `radial-gradient(circle at 100% 100%, transparent 20px, ${scoopColor} 20.5px)`, filter: 'drop-shadow(0 4px 12px rgba(0,0,0,0.12))' }} />
+                <div className="hidden lg:block absolute right-0 w-5 h-5 pointer-events-none z-20" style={{ top: '-1px', background: `radial-gradient(circle at 0% 100%, transparent 20px, ${scoopColor} 20.5px)`, filter: 'drop-shadow(0 4px 12px rgba(0,0,0,0.12))' }} />
+                <div className="h-full overflow-y-auto">
                 {loadError && (
                   <div className="mx-3 mt-2 p-3 bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-700 dark:text-red-300">
                     Failed to load locations. Please try refreshing the page.
@@ -298,6 +311,7 @@ export default function HomePage() {
                   activeConstraints={constraints}
                   enrichments={enrichments}
                 />
+                </div>
               </div>
             </>
           )}
@@ -309,6 +323,7 @@ export default function HomePage() {
         snapTo={snapTarget}
         onHeightChange={handleSheetHeightChange}
         onExpandedChange={handleSheetExpandedChange}
+        scoopColor={isDark ? 'rgba(17,24,39,0.9)' : 'rgba(255,255,255,0.9)'}
         header={
           sheetView === "detail" && detailSlug ? (
             <div className="flex items-center gap-2 px-3 py-1">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -370,8 +370,15 @@ export default function HomePage() {
         header={
           sheetView === "detail" && detailSlug ? (
             <div className="flex items-center gap-2 px-3 py-1">
-              <button onClick={handleBackToList} className="shrink-0 p-1" aria-label="Back to list">
-                <ArrowLeft className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+              <button
+                onClick={handleBackToList}
+                onTouchStart={(e) => e.stopPropagation()}
+                onMouseDown={(e) => e.stopPropagation()}
+                className="shrink-0 p-2.5 -m-1.5 rounded-xl active:bg-gray-200/60 dark:active:bg-gray-700/60"
+                style={{ touchAction: "auto" }}
+                aria-label="Back to list"
+              >
+                <ArrowLeft className="w-5 h-5 text-gray-500 dark:text-gray-400" />
               </button>
               <span className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
                 {allLocations.find((l) => l.slug === detailSlug)?.name ?? "Details"}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -273,12 +273,17 @@ export default function HomePage() {
             </>
           ) : (
             <>
-              <FilterBar
-                filters={filters}
-                onChange={setFilters}
-                resultCount={filteredLocations.length}
-              />
-              <div className="flex-1 overflow-y-auto">
+              <div className="relative z-20">
+                <FilterBar
+                  filters={filters}
+                  onChange={setFilters}
+                  resultCount={filteredLocations.length}
+                />
+                {/* Scooped/inverted corners — concave cutouts hanging from filter bar */}
+                <div className="scoop-left hidden lg:block absolute top-full left-0 w-5 h-5 pointer-events-none z-50" style={{ filter: 'drop-shadow(0 4px 12px rgba(0,0,0,0.12))' }} />
+                <div className="scoop-right hidden lg:block absolute top-full right-0 w-5 h-5 pointer-events-none z-50" style={{ filter: 'drop-shadow(0 4px 12px rgba(0,0,0,0.12))' }} />
+              </div>
+              <div className="flex-1 overflow-y-auto shadow-[inset_0_-6px_12px_rgba(0,0,0,0.08)]">
                 {loadError && (
                   <div className="mx-3 mt-2 p-3 bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-700 dark:text-red-300">
                     Failed to load locations. Please try refreshing the page.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -253,9 +253,22 @@ export default function HomePage() {
             onMarkerHover={handleMarkerHover}
             onUserLocation={handleUserLocation}
           />
-          {/* Floating filter button — above the sheet on mobile, bottom-left on desktop */}
+          {/* Floating filter button — top on mobile (full width) */}
           <div
-            className="absolute left-3 z-20 transition-opacity bottom-4 max-lg:[bottom:calc(var(--sheet-height,96px)+12px)]"
+            className="lg:hidden absolute z-20 left-3 right-3"
+            style={{ top: "calc(0.75rem + env(safe-area-inset-top) + 2.5rem)" }}
+          >
+            <FilterButton
+              filters={filters}
+              constraints={constraints}
+              onClick={() => setPrefsOpen(true)}
+              enrichments={enrichments}
+              fullWidth
+            />
+          </div>
+          {/* Floating filter button — bottom-left on desktop */}
+          <div
+            className="hidden lg:block absolute z-20 left-3 bottom-4"
           >
             <FilterButton
               filters={filters}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -235,12 +235,12 @@ export default function HomePage() {
         {/* Map — edge-to-edge, extends into safe areas */}
         <div className="flex-1 relative overflow-hidden">
           {/* Faded logo overlay — respects safe area */}
-          <div className="absolute left-3 right-3 z-10 flex items-center justify-between" style={{ top: "calc(0.75rem + env(safe-area-inset-top))" }}>
+          <div className="absolute left-3 right-3 lg:right-[calc(24rem*1.2+1.5rem)] z-10 flex items-center justify-between" style={{ top: "calc(0.75rem + env(safe-area-inset-top))" }}>
             <Link href="/" className="flex items-center gap-1.5 opacity-40">
               <Compass className="w-5 h-5 text-blue-600" />
               <span className="font-bold text-blue-700 text-sm">Drift</span>
             </Link>
-            <div className="opacity-70">
+            <div>
               <AuthButton />
             </div>
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef } from "react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { Compass, Search, ArrowLeft } from "lucide-react";
@@ -11,7 +11,7 @@ import FilterButton from "@/components/FilterButton";
 import PreferencePanel from "@/components/PreferencePanel";
 import LocationList from "@/components/LocationList";
 import LocationDetailPanel from "@/components/LocationDetailPanel";
-import BottomSheet, { SNAP_HALF } from "@/components/BottomSheet";
+import BottomSheet, { SNAP_HALF, SNAP_PEEK } from "@/components/BottomSheet";
 import { filterLocations } from "@/lib/filters";
 import { applyConstraints } from "@/lib/constraints";
 import type { PlaceIndexEntry, Filters, Coordinates, Constraints } from "@/lib/types";

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -248,8 +248,24 @@ export default function HomePage() {
       <div className="h-full flex overflow-hidden">
         {/* Map — edge-to-edge, extends into safe areas */}
         <div className="flex-1 relative overflow-hidden">
-          {/* Faded logo overlay — respects safe area */}
-          <div className="absolute left-3 right-3 lg:right-[calc(24rem*1.2+1.5rem)] z-10 flex items-center justify-between" style={{ top: "calc(0.75rem + env(safe-area-inset-top))" }}>
+          {/* Logo + auth — below filter button on mobile */}
+          <div
+            className="lg:hidden absolute left-3 right-3 z-10 flex items-center justify-between"
+            style={{ top: "calc(0.75rem + env(safe-area-inset-top) + 3rem)" }}
+          >
+            <Link href="/" className="flex items-center gap-1.5 opacity-40">
+              <Compass className="w-5 h-5 text-blue-600" />
+              <span className="font-bold text-blue-700 text-sm">Drift</span>
+            </Link>
+            <div>
+              <AuthButton />
+            </div>
+          </div>
+          {/* Logo + auth — top row on desktop */}
+          <div
+            className="hidden lg:flex absolute left-3 right-[calc(24rem*1.2+1.5rem)] z-10 items-center justify-between"
+            style={{ top: "calc(0.75rem + env(safe-area-inset-top))" }}
+          >
             <Link href="/" className="flex items-center gap-1.5 opacity-40">
               <Compass className="w-5 h-5 text-blue-600" />
               <span className="font-bold text-blue-700 text-sm">Drift</span>
@@ -270,7 +286,7 @@ export default function HomePage() {
           {/* Floating filter button — top on mobile (full width) */}
           <div
             className="lg:hidden absolute z-20 left-3 right-3"
-            style={{ top: "calc(0.75rem + env(safe-area-inset-top) + 2.5rem)" }}
+            style={{ top: "calc(0.75rem + env(safe-area-inset-top))" }}
           >
             <FilterButton
               filters={filters}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -369,11 +369,14 @@ export default function HomePage() {
         scoopColor={isDark ? 'rgba(17,24,39,0.9)' : 'rgba(255,255,255,0.9)'}
         header={
           sheetView === "detail" && detailSlug ? (
-            <div className="flex items-center gap-2 px-3 py-1">
+            /* Stop all drags on the detail header — prevents sheet cycling on touch */
+            <div
+              className="flex items-center gap-2 px-3 py-1"
+              onTouchStart={(e) => e.stopPropagation()}
+              onMouseDown={(e) => e.stopPropagation()}
+            >
               <button
                 onClick={handleBackToList}
-                onTouchStart={(e) => e.stopPropagation()}
-                onMouseDown={(e) => e.stopPropagation()}
                 className="shrink-0 p-2.5 -m-1.5 rounded-xl active:bg-gray-200/60 dark:active:bg-gray-700/60"
                 style={{ touchAction: "auto" }}
                 aria-label="Back to list"
@@ -447,7 +450,14 @@ export default function HomePage() {
       {/* Preference panel (modal overlay) */}
       <PreferencePanel
         open={prefsOpen}
-        onClose={() => setPrefsOpen(false)}
+        onClose={() => {
+          setPrefsOpen(false);
+          // If the sheet is fully collapsed (peek), expand to middle so the
+          // updated list is visible without the user needing to drag it up.
+          if (!isSheetExpanded) {
+            setSnapTarget(window.innerHeight * SNAP_HALF);
+          }
+        }}
         filters={filters}
         constraints={constraints}
         onFiltersChange={setFilters}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -254,11 +254,11 @@ export default function HomePage() {
           </div>
         </div>
 
-        {/* Desktop sidebar (hidden on mobile) */}
-        <div data-testid="location-sidebar" className="hidden lg:flex lg:flex-col lg:w-96 lg:border-l lg:border-gray-200 dark:lg:border-gray-700 dark:bg-gray-900">
+        {/* Desktop sidebar — floats over map */}
+        <div data-testid="location-sidebar" className="hidden lg:flex lg:flex-col lg:w-[24rem] absolute right-3 top-3 bottom-3 z-20 bg-white/80 dark:bg-gray-900/80 backdrop-blur-xl rounded-2xl shadow-2xl border border-white/50 dark:border-gray-700/50 overflow-hidden [zoom:1.2]">
           {detailSlug && sheetView === "detail" ? (
             <>
-              <div className="p-3 border-b border-gray-200 dark:border-gray-700 flex items-center gap-2">
+              <div className="p-3 border-b border-white/30 dark:border-gray-700 flex items-center gap-2">
                 <button
                   onClick={handleBackToListDesktop}
                   className="flex items-center gap-1.5 text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 transition-colors"
@@ -316,7 +316,7 @@ export default function HomePage() {
             </div>
           ) : (
             <>
-              <div className="flex items-center gap-2 px-3 py-1 border-b border-gray-100 dark:border-gray-800">
+              <div className="flex items-center gap-2 mx-3 my-1 px-3 py-2 bg-white/60 dark:bg-gray-800/60 rounded-xl border border-gray-200/50 dark:border-gray-700/50 shadow-sm">
                 <Search className="w-4 h-4 text-gray-400 dark:text-gray-500 shrink-0" />
                 <input
                   type="text"

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -75,6 +75,10 @@ export default function BottomSheet({ children, header, snapTo, onHeightChange, 
   const lastTouchTime = useRef(0);
   const velocityRef = useRef(0);
 
+  // Pull-to-collapse: track when a scroll-area touch should become a panel drag
+  const scrollTouchStartY = useRef(0);
+  const scrollDragActive = useRef(false);
+
   // Write height directly to the DOM — no React re-render
   const applyHeight = useCallback((h: number) => {
     heightRef.current = h;
@@ -288,6 +292,59 @@ export default function BottomSheet({ children, header, snapTo, onHeightChange, 
     };
   }, [handleDragMove, handleDragEnd, handleHandleTap]);
 
+  // Pull-to-collapse: when scrolled to top and pulling down, drag the panel
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const onTouchStart = (e: TouchEvent) => {
+      scrollTouchStartY.current = e.touches[0].clientY;
+      scrollDragActive.current = false;
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      const clientY = e.touches[0].clientY;
+      const pullingDown = clientY > scrollTouchStartY.current;
+
+      // If already dragging the panel, continue
+      if (scrollDragActive.current) {
+        e.preventDefault();
+        handleDragMove(clientY);
+        return;
+      }
+
+      // Transition to panel drag if at scroll top and pulling down
+      if (pullingDown && el.scrollTop <= 0) {
+        scrollDragActive.current = true;
+        e.preventDefault();
+        handleDragStart(clientY);
+        return;
+      }
+    };
+
+    const onTouchEnd = () => {
+      if (scrollDragActive.current) {
+        scrollDragActive.current = false;
+        draggingRef.current = false;
+        if (dragDistanceRef.current < 5) {
+          handleHandleTap();
+        } else {
+          handleDragEnd();
+        }
+      }
+    };
+
+    el.addEventListener("touchstart", onTouchStart, { passive: true });
+    el.addEventListener("touchmove", onTouchMove, { passive: false });
+    el.addEventListener("touchend", onTouchEnd);
+
+    return () => {
+      el.removeEventListener("touchstart", onTouchStart);
+      el.removeEventListener("touchmove", onTouchMove);
+      el.removeEventListener("touchend", onTouchEnd);
+    };
+  }, [handleDragStart, handleDragMove, handleDragEnd, handleHandleTap]);
+
   useEffect(() => {
     return () => cancelSpring.current?.();
   }, []);
@@ -313,13 +370,18 @@ export default function BottomSheet({ children, header, snapTo, onHeightChange, 
 
       {/* Header — outside scroll, popovers can overflow visibly */}
       {header && (
-        <div className={`shrink-0 relative z-10 overflow-visible transition-shadow duration-200 ${scrolled ? 'shadow-[0_4px_12px_rgba(0,0,0,0.12)]' : ''}`}>
+        <div
+          className={`shrink-0 relative z-10 overflow-visible transition-shadow duration-200 ${scrolled ? 'shadow-[0_4px_12px_rgba(0,0,0,0.12)]' : ''}`}
+          style={{ touchAction: "none" }}
+          onTouchStart={(e) => handleDragStart(e.touches[0].clientY)}
+          onMouseDown={(e) => handleDragStart(e.clientY)}
+        >
           {header}
           {/* Scooped/inverted corners — visible only when scrolled */}
           {scrolled && (
             <>
-              <div className="absolute top-full left-0 w-5 h-5 pointer-events-none z-50" style={{ background: 'radial-gradient(circle at 100% 100%, transparent 20px, rgba(255,255,255,0.9) 20.5px)', filter: 'drop-shadow(0 4px 12px rgba(0,0,0,0.12))' }} />
-              <div className="absolute top-full right-0 w-5 h-5 pointer-events-none z-50" style={{ background: 'radial-gradient(circle at 0 100%, transparent 20px, rgba(255,255,255,0.9) 20.5px)', filter: 'drop-shadow(0 4px 12px rgba(0,0,0,0.12))' }} />
+              <div className="scoop-left absolute top-full left-0 w-5 h-5 pointer-events-none z-50" style={{ filter: 'drop-shadow(0 4px 12px rgba(0,0,0,0.12))' }} />
+              <div className="scoop-right absolute top-full right-0 w-5 h-5 pointer-events-none z-50" style={{ filter: 'drop-shadow(0 4px 12px rgba(0,0,0,0.12))' }} />
             </>
           )}
         </div>

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -300,7 +300,7 @@ export default function BottomSheet({ children, header, snapTo, onHeightChange, 
     >
       {/* Drag handle — enlarged 48px hit target */}
       <div
-        className="flex items-center justify-center h-12 cursor-grab active:cursor-grabbing shrink-0"
+        className="flex items-center justify-center h-5 cursor-grab active:cursor-grabbing shrink-0"
         style={{ touchAction: "none" }}
         onMouseDown={(e) => handleDragStart(e.clientY)}
         onTouchStart={(e) => {

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -54,9 +54,11 @@ interface BottomSheetProps {
   onHeightChange?: (height: number) => void;
   /** Fires only when crossing the expanded/collapsed threshold */
   onExpandedChange?: (expanded: boolean) => void;
+  /** Color for scooped corner backgrounds */
+  scoopColor?: string;
 }
 
-export default function BottomSheet({ children, header, snapTo, onHeightChange, onExpandedChange }: BottomSheetProps) {
+export default function BottomSheet({ children, header, snapTo, onHeightChange, onExpandedChange, scoopColor = 'rgba(255,255,255,0.9)' }: BottomSheetProps) {
   const sheetRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   // React state only used for content-visibility threshold — NOT updated per pixel
@@ -380,8 +382,8 @@ export default function BottomSheet({ children, header, snapTo, onHeightChange, 
           {/* Scooped/inverted corners — visible only when scrolled */}
           {scrolled && (
             <>
-              <div className="scoop-left absolute top-full left-0 w-5 h-5 pointer-events-none z-50" style={{ filter: 'drop-shadow(0 4px 12px rgba(0,0,0,0.12))' }} />
-              <div className="scoop-right absolute top-full right-0 w-5 h-5 pointer-events-none z-50" style={{ filter: 'drop-shadow(0 4px 12px rgba(0,0,0,0.12))' }} />
+              <div className="absolute top-full left-0 w-5 h-5 pointer-events-none z-50" style={{ background: `radial-gradient(circle at 100% 100%, transparent 20px, ${scoopColor} 20.5px)`, filter: 'drop-shadow(0 4px 12px rgba(0,0,0,0.12))' }} />
+              <div className="absolute top-full right-0 w-5 h-5 pointer-events-none z-50" style={{ background: `radial-gradient(circle at 0 100%, transparent 20px, ${scoopColor} 20.5px)`, filter: 'drop-shadow(0 4px 12px rgba(0,0,0,0.12))' }} />
             </>
           )}
         </div>

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -117,7 +117,7 @@ export default function BottomSheet({ children, header, snapTo, onHeightChange, 
   }, []);
 
   const getSnaps = useCallback(() => {
-    const vh = window.innerHeight;
+    const vh = Math.max(window.innerHeight, 200); // guard against 0 during early layout
     return [SNAP_PEEK, vh * SNAP_HALF, vh * SNAP_FULL];
   }, []);
 
@@ -311,6 +311,7 @@ export default function BottomSheet({ children, header, snapTo, onHeightChange, 
       // If already dragging the panel, continue
       if (scrollDragActive.current) {
         e.preventDefault();
+        e.stopPropagation(); // prevent window touchmove from double-counting distance
         handleDragMove(clientY);
         return;
       }

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -58,8 +58,10 @@ interface BottomSheetProps {
 
 export default function BottomSheet({ children, header, snapTo, onHeightChange, onExpandedChange }: BottomSheetProps) {
   const sheetRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
   // React state only used for content-visibility threshold — NOT updated per pixel
   const [, setIsExpanded] = useState(false);
+  const [scrolled, setScrolled] = useState(false);
   const heightRef = useRef(SNAP_PEEK);
   const draggingRef = useRef(false);
   const animatingRef = useRef(false);
@@ -93,6 +95,20 @@ export default function BottomSheet({ children, header, snapTo, onHeightChange, 
   useEffect(() => {
     applyHeight(SNAP_PEEK);
   }, [applyHeight]);
+
+  // Show shadow/corners when filter bar area has scrolled out of view
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      // Show once scrolled past the first child (filter bar area)
+      const firstChild = el.firstElementChild as HTMLElement | null;
+      const threshold = firstChild?.offsetHeight ?? 0;
+      setScrolled(el.scrollTop >= threshold);
+    };
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, []);
 
   const getSnaps = useCallback(() => {
     const vh = window.innerHeight;
@@ -279,7 +295,7 @@ export default function BottomSheet({ children, header, snapTo, onHeightChange, 
   return (
     <div
       ref={sheetRef}
-      className="fixed bottom-0 left-0 right-0 bg-white/75 dark:bg-gray-900/80 backdrop-blur-xl rounded-t-2xl shadow-[0_-4px_24px_rgba(0,0,0,0.15)] dark:shadow-[0_-4px_24px_rgba(0,0,0,0.5)] border-t border-white/50 dark:border-gray-700/50 z-40 flex flex-col lg:hidden"
+      className="fixed bottom-2 left-2 right-2 bg-white/90 dark:bg-gray-900/90 backdrop-blur-xl rounded-2xl shadow-[0_-4px_24px_rgba(0,0,0,0.15)] dark:shadow-[0_-4px_24px_rgba(0,0,0,0.5)] border border-white/50 dark:border-gray-700/50 z-40 flex flex-col lg:hidden"
       style={{ height: SNAP_PEEK }}
     >
       {/* Drag handle — enlarged 48px hit target */}
@@ -297,13 +313,20 @@ export default function BottomSheet({ children, header, snapTo, onHeightChange, 
 
       {/* Header — outside scroll, popovers can overflow visibly */}
       {header && (
-        <div className="shrink-0 relative z-10 overflow-visible shadow-[0_4px_12px_rgba(0,0,0,0.06)]">
+        <div className={`shrink-0 relative z-10 overflow-visible transition-shadow duration-200 ${scrolled ? 'shadow-[0_4px_12px_rgba(0,0,0,0.12)]' : ''}`}>
           {header}
+          {/* Scooped/inverted corners — visible only when scrolled */}
+          {scrolled && (
+            <>
+              <div className="absolute top-full left-0 w-5 h-5 pointer-events-none z-50" style={{ background: 'radial-gradient(circle at 100% 100%, transparent 20px, rgba(255,255,255,0.9) 20.5px)', filter: 'drop-shadow(0 4px 12px rgba(0,0,0,0.12))' }} />
+              <div className="absolute top-full right-0 w-5 h-5 pointer-events-none z-50" style={{ background: 'radial-gradient(circle at 0 100%, transparent 20px, rgba(255,255,255,0.9) 20.5px)', filter: 'drop-shadow(0 4px 12px rgba(0,0,0,0.12))' }} />
+            </>
+          )}
         </div>
       )}
 
       {/* Scrollable content */}
-      <div className="flex-1 overflow-y-auto overscroll-contain">
+      <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain">
         {children}
       </div>
     </div>

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -279,7 +279,7 @@ export default function BottomSheet({ children, header, snapTo, onHeightChange, 
   return (
     <div
       ref={sheetRef}
-      className="fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-900 rounded-t-2xl shadow-[0_-2px_16px_rgba(0,0,0,0.12)] dark:shadow-[0_-2px_16px_rgba(0,0,0,0.4)] z-40 flex flex-col lg:hidden"
+      className="fixed bottom-0 left-0 right-0 bg-white/75 dark:bg-gray-900/80 backdrop-blur-xl rounded-t-2xl shadow-[0_-4px_24px_rgba(0,0,0,0.15)] dark:shadow-[0_-4px_24px_rgba(0,0,0,0.5)] border-t border-white/50 dark:border-gray-700/50 z-40 flex flex-col lg:hidden"
       style={{ height: SNAP_PEEK }}
     >
       {/* Drag handle — enlarged 48px hit target */}
@@ -297,7 +297,7 @@ export default function BottomSheet({ children, header, snapTo, onHeightChange, 
 
       {/* Header — outside scroll, popovers can overflow visibly */}
       {header && (
-        <div className="shrink-0 relative z-10 overflow-visible">
+        <div className="shrink-0 relative z-10 overflow-visible shadow-[0_4px_12px_rgba(0,0,0,0.06)]">
           {header}
         </div>
       )}

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -60,7 +60,7 @@ export default function BottomSheet({ children, header, snapTo, onHeightChange, 
   const sheetRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   // React state only used for content-visibility threshold — NOT updated per pixel
-  const [, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
   const [scrolled, setScrolled] = useState(false);
   const heightRef = useRef(SNAP_PEEK);
   const draggingRef = useRef(false);
@@ -295,7 +295,7 @@ export default function BottomSheet({ children, header, snapTo, onHeightChange, 
   return (
     <div
       ref={sheetRef}
-      className="fixed bottom-2 left-2 right-2 bg-white/90 dark:bg-gray-900/90 backdrop-blur-xl rounded-2xl shadow-[0_-4px_24px_rgba(0,0,0,0.15)] dark:shadow-[0_-4px_24px_rgba(0,0,0,0.5)] border border-white/50 dark:border-gray-700/50 z-40 flex flex-col lg:hidden"
+      className="fixed bottom-2 left-2 right-2 bg-white/90 dark:bg-gray-900/90 backdrop-blur-xl rounded-3xl shadow-[0_-4px_24px_rgba(0,0,0,0.15)] dark:shadow-[0_-4px_24px_rgba(0,0,0,0.5)] border border-white/50 dark:border-gray-700/50 z-40 flex flex-col lg:hidden"
       style={{ height: SNAP_PEEK }}
     >
       {/* Drag handle — enlarged 48px hit target */}
@@ -326,7 +326,7 @@ export default function BottomSheet({ children, header, snapTo, onHeightChange, 
       )}
 
       {/* Scrollable content */}
-      <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain">
+      <div ref={scrollRef} className={`flex-1 overflow-y-auto overscroll-contain rounded-b-3xl ${isExpanded ? 'shadow-[inset_0_-6px_12px_rgba(0,0,0,0.08)]' : ''}`}>
         {children}
       </div>
     </div>

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -166,12 +166,12 @@ export default function FilterBar({
 
   return (
     <div
-      className="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900"
+      className="border-b border-white/30 dark:border-gray-700 bg-transparent relative z-10 shadow-[0_4px_12px_rgba(0,0,0,0.06)]"
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
       {!hideSearch && (
-        <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-100 dark:border-gray-800">
+        <div className="flex items-center gap-2 mx-3 mt-2 mb-1 px-3 py-2 bg-white/60 dark:bg-gray-800/60 rounded-xl border border-gray-200/50 dark:border-gray-700/50 shadow-sm">
           <Search className="w-4 h-4 text-gray-400 dark:text-gray-500 shrink-0" />
           <input
             type="text"
@@ -185,7 +185,7 @@ export default function FilterBar({
       )}
       <div
         ref={chipsRef}
-        className="flex items-center gap-2 px-3 py-2 overflow-x-auto scrollbar-hide md:flex-wrap md:overflow-x-visible"
+        className="flex items-center gap-2 px-3 pt-1 pb-2 overflow-x-auto scrollbar-hide md:flex-wrap md:overflow-x-visible"
         style={chipsStyle}
       >
         {orderedTypeChips.map((chip) => {
@@ -202,7 +202,7 @@ export default function FilterBar({
               className={`shrink-0 px-3 py-1 text-sm rounded-full border transition-colors ${
                 isActive
                   ? "bg-blue-600 text-white border-blue-600"
-                  : "bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500"
+                  : "bg-white/50 dark:bg-gray-800/50 text-gray-700 dark:text-gray-300 border-gray-300/50 dark:border-gray-600 hover:bg-white/80 dark:hover:bg-gray-800/80"
               }`}
               data-filter-chip={chip.value}
             >
@@ -211,7 +211,7 @@ export default function FilterBar({
           );
         })}
 
-        <div className="w-px h-5 bg-gray-200 dark:bg-gray-700 shrink-0" />
+        <div className="w-px h-5 bg-gray-300/50 dark:bg-gray-700 shrink-0" />
 
         {orderedStatusChips.map((chip) => {
           const isActive = filters.siteStatus === chip.value;
@@ -227,7 +227,7 @@ export default function FilterBar({
               className={`shrink-0 px-3 py-1 text-sm rounded-full border transition-colors ${
                 isActive
                   ? "bg-blue-600 text-white border-blue-600"
-                  : "bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500"
+                  : "bg-white/50 dark:bg-gray-800/50 text-gray-700 dark:text-gray-300 border-gray-300/50 dark:border-gray-600 hover:bg-white/80 dark:hover:bg-gray-800/80"
               }`}
               data-filter-chip={chip.value}
             >

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -166,7 +166,7 @@ export default function FilterBar({
 
   return (
     <div
-      className="border-b border-white/30 dark:border-gray-700 bg-transparent relative z-10 shadow-[0_4px_12px_rgba(0,0,0,0.06)]"
+      className="border-b border-white/30 dark:border-gray-700 bg-transparent relative shadow-[0_4px_12px_rgba(0,0,0,0.12)] pb-0.5"
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >

--- a/src/components/FilterButton.tsx
+++ b/src/components/FilterButton.tsx
@@ -11,9 +11,10 @@ interface FilterButtonProps {
   constraints: Constraints;
   onClick: () => void;
   enrichments?: EnrichmentIndex | null;
+  fullWidth?: boolean;
 }
 
-export default function FilterButton({ filters, constraints, onClick, enrichments }: FilterButtonProps) {
+export default function FilterButton({ filters, constraints, onClick, enrichments, fullWidth }: FilterButtonProps) {
   const count = activeFilterCount(filters, constraints);
 
   // Pick a representative forecast (first enriched location) for the sentence preamble
@@ -30,9 +31,9 @@ export default function FilterButton({ filters, constraints, onClick, enrichment
       onClick={onClick}
       aria-label="Open filter preferences"
       aria-haspopup="dialog"
-      className="flex items-start gap-2 backdrop-blur-md bg-white/85 dark:bg-gray-900/85
+      className={`flex items-start gap-2 backdrop-blur-md bg-white/85 dark:bg-gray-900/85
                  rounded-2xl shadow-lg border border-white/60 dark:border-gray-700/60
-                 px-3 py-2 lg:px-4 lg:py-2.5 transition-all hover:shadow-xl active:scale-[0.98]"
+                 px-3 py-2 lg:px-4 lg:py-2.5 transition-all hover:shadow-xl active:scale-[0.98]${fullWidth ? ' w-full' : ''}`}
     >
       <div className="relative mt-0.5">
         <SlidersHorizontal className="w-4 h-4 lg:w-5 lg:h-5 text-gray-600 dark:text-gray-300" />

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -4,7 +4,6 @@ import { useRef, useState } from "react";
 import Link from "next/link";
 import type { PlaceIndexEntry, Coordinates, Constraints } from "@/lib/types";
 import { haversineDistanceKm, formatDistance } from "@/lib/useCurrentLocation";
-import { buildFitParagraph } from "@/lib/fit";
 import type { EnrichmentIndex } from "@/lib/integrations/enrichment-types";
 import { useEdgeColor, darkenEdgeColor } from "@/lib/useEdgeColor";
 import TypeBadge from "./TypeBadge";
@@ -29,8 +28,8 @@ export default function LocationCard({
   isHighlighted,
   userLocation,
   onCardClick,
-  activeConstraints,
-  enrichments,
+  activeConstraints: _activeConstraints,
+  enrichments: _enrichments,
 }: LocationCardProps) {
   const driveMinutes = (location as { _driveMinutes?: number | null })._driveMinutes;
   const distance = driveMinutes != null
@@ -50,7 +49,7 @@ export default function LocationCard({
   const photo = imgFailed ? undefined : photoUrl;
 
   const cardRef = useRef<HTMLElement>(null);
-  const fitBlurb = buildFitParagraph(location.fit, activeConstraints ?? null, location, enrichments ?? null, driveMinutes);
+  // Fit blurb intentionally not shown on cards (shown in detail panel only)
   const hoursStatus = formatHoursStatus(location.openingHours);
 
   const edgeColor = useEdgeColor(photo, cardRef);
@@ -63,12 +62,8 @@ export default function LocationCard({
       : "border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm hover:shadow-md"
   }`;
 
-  // Shared bottom row: highlights / fit / tags
-  const bottomRow = fitBlurb ? (
-    <p className={`text-sm mt-1.5 ${photo ? "max-w-[65%] text-white/90 drop-shadow-[0_1px_3px_rgba(0,0,0,0.6)]" : "line-clamp-2 text-emerald-700 dark:text-emerald-400"}`}>
-      {fitBlurb}
-    </p>
-  ) : location.highlights.length > 0 ? (
+  // Shared bottom row: highlights / tags (no fit blurb)
+  const bottomRow = location.highlights.length > 0 ? (
     <p className={`text-sm mt-1.5 ${photo ? "max-w-[65%] text-white/80 drop-shadow-[0_1px_3px_rgba(0,0,0,0.6)]" : "line-clamp-1 text-gray-600 dark:text-gray-400"}`}>
       {location.highlights[0]}
     </p>

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import Link from "next/link";
 import type { PlaceIndexEntry, Coordinates, Constraints } from "@/lib/types";
 import { haversineDistanceKm, formatDistance } from "@/lib/useCurrentLocation";
@@ -45,7 +45,9 @@ export default function LocationCard({
       ? formatDistance(haversineDistanceKm(userLocation, location.coordinates))
       : null;
 
-  const photo = location.photo && !location.photo.includes("placeholder") ? location.photo : undefined;
+  const photoUrl = location.photo && !location.photo.includes("placeholder") ? location.photo : undefined;
+  const [imgFailed, setImgFailed] = useState(false);
+  const photo = imgFailed ? undefined : photoUrl;
 
   const cardRef = useRef<HTMLElement>(null);
   const fitBlurb = buildFitParagraph(location.fit, activeConstraints ?? null, location, enrichments ?? null, driveMinutes);
@@ -129,6 +131,7 @@ export default function LocationCard({
           alt=""
           loading="lazy"
           crossOrigin="anonymous"
+          onError={() => setImgFailed(true)}
           className="w-full h-full object-cover brightness-90 saturate-[0.85]"
         />
       </div>

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -128,6 +128,7 @@ export default function LocationCard({
           src={photo}
           alt=""
           loading="lazy"
+          crossOrigin="anonymous"
           className="w-full h-full object-cover brightness-90 saturate-[0.85]"
         />
       </div>

--- a/src/components/LocationDetailPanel.tsx
+++ b/src/components/LocationDetailPanel.tsx
@@ -326,12 +326,10 @@ export default function LocationDetailPanel({
     <div className="px-4 pb-6">
       {/* Title and badges */}
       <div className="mb-3">
-        <div className="flex items-start justify-between gap-2">
-          <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">{location.name}</h2>
-          <div className="flex gap-1.5 shrink-0">
-            <BookmarkButton slug={location.slug} />
-            <VisitedButton slug={location.slug} />
-          </div>
+        <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">{location.name}</h2>
+        <div className="flex items-center gap-2 mt-1.5">
+          <BookmarkButton slug={location.slug} />
+          <VisitedButton slug={location.slug} />
         </div>
         <div className="flex items-center gap-2 mt-1">
           <TypeBadge type={location.type} />

--- a/src/components/LocationMap.tsx
+++ b/src/components/LocationMap.tsx
@@ -6,7 +6,7 @@ import "leaflet/dist/leaflet.css";
 import "leaflet.markercluster";
 import "leaflet.markercluster/dist/MarkerCluster.css";
 import "leaflet.markercluster/dist/MarkerCluster.Default.css";
-import { Crosshair } from "lucide-react";
+import { Crosshair, Plus, Minus } from "lucide-react";
 
 import type { PlaceIndexEntry, PlaceType, Coordinates, OpeningHoursEntry } from "@/lib/types";
 import type { ScoredPlace } from "@/lib/constraints";
@@ -244,8 +244,6 @@ export default function LocationMap({
       );
     };
     mql.addEventListener("change", onThemeChange);
-
-    L.control.zoom({ position: "topright" }).addTo(map);
 
     const clusterGroup = L.markerClusterGroup({
       maxClusterRadius: 50,
@@ -586,23 +584,45 @@ export default function LocationMap({
     <div className="relative h-full w-full">
       <div ref={mapContainerRef} className="h-full w-full isolate" />
 
-      {/* Locate me button — positioned above mobile bottom sheet */}
-      <button
-        onClick={handleLocateMe}
-        disabled={locating}
-        aria-label="Show my location"
-        data-testid="locate-button"
-        className="absolute right-4 z-50 flex h-10 w-10 items-center justify-center rounded-full bg-white dark:bg-gray-800 shadow-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700 active:bg-gray-100 dark:active:bg-gray-600 transition-colors disabled:opacity-60 lg:bottom-4"
-        style={{ bottom: `calc(var(--sheet-height, 96px) + 84px)` }}
+      {/* Zoom + locate controls — positioned above mobile bottom sheet */}
+      <div
+        className="absolute right-4 z-50 flex flex-col gap-2 lg:bottom-4"
+        style={{ bottom: `calc(var(--sheet-height, 96px) + 20px)` }}
       >
-        <Crosshair className={`w-5 h-5 text-blue-600 ${locating ? "animate-spin" : ""}`} />
-      </button>
+        {/* Zoom in/out */}
+        <div className="flex flex-col rounded-xl overflow-hidden shadow-[0_2px_8px_rgba(0,0,0,0.15)] dark:shadow-[0_2px_8px_rgba(0,0,0,0.4)]">
+          <button
+            onClick={() => mapRef.current?.zoomIn()}
+            aria-label="Zoom in"
+            className="flex items-center justify-center w-[36px] h-[36px] bg-white dark:bg-[#1e293b] hover:bg-[#f1f5f9] dark:hover:bg-[#334155] active:bg-[#e2e8f0] dark:active:bg-[#475569] transition-colors border-b border-[#e2e8f0] dark:border-[#334155]"
+          >
+            <Plus className="w-[18px] h-[18px] text-[#334155] dark:text-[#94a3b8]" strokeWidth={2.5} />
+          </button>
+          <button
+            onClick={() => mapRef.current?.zoomOut()}
+            aria-label="Zoom out"
+            className="flex items-center justify-center w-[36px] h-[36px] bg-white dark:bg-[#1e293b] hover:bg-[#f1f5f9] dark:hover:bg-[#334155] active:bg-[#e2e8f0] dark:active:bg-[#475569] transition-colors"
+          >
+            <Minus className="w-[18px] h-[18px] text-[#334155] dark:text-[#94a3b8]" strokeWidth={2.5} />
+          </button>
+        </div>
+        {/* Locate me */}
+        <button
+          onClick={handleLocateMe}
+          disabled={locating}
+          aria-label="Show my location"
+          data-testid="locate-button"
+          className="flex items-center justify-center w-[36px] h-[36px] rounded-xl bg-white dark:bg-[#1e293b] shadow-[0_2px_8px_rgba(0,0,0,0.15)] dark:shadow-[0_2px_8px_rgba(0,0,0,0.4)] hover:bg-[#f1f5f9] dark:hover:bg-[#334155] active:bg-[#e2e8f0] dark:active:bg-[#475569] transition-colors disabled:opacity-60"
+        >
+          <Crosshair className={`w-[18px] h-[18px] text-[#334155] dark:text-[#94a3b8] ${locating ? "animate-spin" : ""}`} />
+        </button>
+      </div>
 
       {/* Error toast */}
       {locateError && (
         <div
           className="absolute right-4 z-50 rounded-lg bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 px-3 py-2 text-sm text-red-700 dark:text-red-300 shadow-md lg:bottom-16"
-          style={{ bottom: `calc(var(--sheet-height, 96px) + 132px)` }}
+          style={{ bottom: `calc(var(--sheet-height, 96px) + 160px)` }}
         >
           {locateError}
         </div>

--- a/src/components/LocationMap.tsx
+++ b/src/components/LocationMap.tsx
@@ -335,6 +335,7 @@ export default function LocationMap({
       map.remove();
       mapRef.current = null;
       clusterGroupRef.current = null;
+      if (window.__leafletMap === map) window.__leafletMap = undefined;
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/components/LocationMap.tsx
+++ b/src/components/LocationMap.tsx
@@ -586,8 +586,7 @@ export default function LocationMap({
 
       {/* Zoom + locate controls — positioned above mobile bottom sheet */}
       <div
-        className="absolute right-4 z-50 flex flex-col gap-2 lg:bottom-4"
-        style={{ bottom: `calc(var(--sheet-height, 96px) + 20px)` }}
+        className="absolute right-4 z-50 flex flex-col gap-2 lg:bottom-3 lg:right-[calc(24rem*1.2+1.5rem)] max-lg:[bottom:calc(var(--sheet-height,96px)+20px)]"
       >
         {/* Zoom in/out */}
         <div className="flex flex-col rounded-xl overflow-hidden shadow-[0_2px_8px_rgba(0,0,0,0.15)] dark:shadow-[0_2px_8px_rgba(0,0,0,0.4)]">

--- a/src/lib/useEdgeColor.ts
+++ b/src/lib/useEdgeColor.ts
@@ -7,11 +7,8 @@ const cache = new Map<string, string>();
 const MAX_CACHE = 80;
 
 /**
- * Extracts the average color from the left edge of an image.
+ * Extracts the most common color from the visible region of a card's image.
  * Returns an "r, g, b" string for use in rgba(), or null while loading / on failure.
- *
- * Pass an optional ref to a container element — extraction is deferred until the
- * element is within 200px of the viewport (IntersectionObserver with rootMargin).
  */
 export function useEdgeColor(
   src: string | undefined,
@@ -21,7 +18,6 @@ export function useEdgeColor(
   const [asyncColor, setAsyncColor] = useState<string | null>(null);
   const [visible, setVisible] = useState(!containerRef);
 
-  // Observe visibility when a container ref is provided
   const observerCallback = useCallback(([entry]: IntersectionObserverEntry[]) => {
     if (entry.isIntersecting) {
       setVisible(true);
@@ -53,33 +49,72 @@ export function useEdgeColor(
         if (!ctx) return;
 
         if (img.naturalHeight <= 0 || img.naturalWidth <= 0) return;
-        const h = 40;
+        const h = 16;
         const w = Math.round((img.naturalWidth / img.naturalHeight) * h);
         if (!isFinite(w) || w <= 0 || w > 10000) return;
         canvas.width = w;
         canvas.height = h;
         ctx.drawImage(img, 0, 0, w, h);
 
-        // Sample left 8% strip
-        const stripW = Math.max(1, Math.round(w * 0.08));
-        const data = ctx.getImageData(0, 0, stripW, h).data;
+        // Sample only the visible cropped region (~right 77% of image)
+        const visibleLeft = Math.round(w * 0.23);
+        const visibleW = w - visibleLeft;
+        const data = ctx.getImageData(visibleLeft, 0, visibleW, h).data;
+        const totalPixels = visibleW * h;
 
-        let r = 0,
-          g = 0,
-          b = 0;
-        const count = stripW * h;
+        // Fast bucketing with typed arrays (3-bit per channel = 512 buckets)
+        const bucketCount = new Uint16Array(512);
+        const bucketR = new Uint32Array(512);
+        const bucketG = new Uint32Array(512);
+        const bucketB = new Uint32Array(512);
+
         for (let i = 0; i < data.length; i += 4) {
-          r += data[i];
-          g += data[i + 1];
-          b += data[i + 2];
+          const pr = data[i], pg = data[i + 1], pb = data[i + 2];
+          const max = Math.max(pr, pg, pb);
+          const min = Math.min(pr, pg, pb);
+          if (max < 30 || min > 225) continue;
+
+          const key = ((pr >> 5) << 6) | ((pg >> 5) << 3) | (pb >> 5);
+          bucketCount[key]++;
+          bucketR[key] += pr;
+          bucketG[key] += pg;
+          bucketB[key] += pb;
         }
-        r = Math.round(r / count);
-        g = Math.round(g / count);
-        b = Math.round(b / count);
 
-        const result = `${r}, ${g}, ${b}`;
+        // Find best bucket, biased toward warm colors
+        let bestIdx = -1;
+        let bestScore = -1;
+        for (let i = 0; i < 512; i++) {
+          const cnt = bucketCount[i];
+          if (cnt === 0) continue;
+          const ar = bucketR[i] / cnt;
+          const ab = bucketB[i] / cnt;
+          const warmth = 1 + Math.max(0, (ar - ab) / 255);
+          const score = cnt * warmth;
+          if (score > bestScore) {
+            bestScore = score;
+            bestIdx = i;
+          }
+        }
 
-        // Evict oldest entries if cache is full
+        let bestR: number, bestG: number, bestB: number;
+        if (bestIdx >= 0) {
+          const cnt = bucketCount[bestIdx];
+          bestR = Math.round(bucketR[bestIdx] / cnt);
+          bestG = Math.round(bucketG[bestIdx] / cnt);
+          bestB = Math.round(bucketB[bestIdx] / cnt);
+        } else {
+          let sr = 0, sg = 0, sb = 0;
+          for (let i = 0; i < data.length; i += 4) {
+            sr += data[i]; sg += data[i + 1]; sb += data[i + 2];
+          }
+          bestR = Math.round(sr / totalPixels);
+          bestG = Math.round(sg / totalPixels);
+          bestB = Math.round(sb / totalPixels);
+        }
+
+        const result = `${bestR}, ${bestG}, ${bestB}`;
+
         if (cache.size >= MAX_CACHE) {
           const first = cache.keys().next().value;
           if (first !== undefined) cache.delete(first);
@@ -92,17 +127,11 @@ export function useEdgeColor(
       }
     };
 
-    img.onerror = () => {
-      // Image failed to load — leave null
-    };
-
+    img.onerror = () => {};
     img.src = src;
-    return () => {
-      cancelled = true;
-    };
+    return () => { cancelled = true; };
   }, [src, visible]);
 
-  // Cache hit takes priority; async state is fallback for first load
   return cached ?? asyncColor;
 }
 


### PR DESCRIPTION
## Summary

Complete UI redesign implementing a floating frosted-glass aesthetic for the Drift PWA, resolving Issue #40.

## Changes

### Core UI Redesign
- **Floating sidebar (desktop)**: Frosted-glass panel with `[zoom:1.2]` scale, rounded corners, backdrop blur, positioned away from screen edges
- **Floating bottom sheet (mobile)**: Frosted-glass panel with scooped/inverted corners, spring-physics snapping (peek/middle/full)
- **Scooped corners**: Radial-gradient inverted corner divs that appear on scroll, matching dark/light theme
- **Dark mode support**: JS `matchMedia` for inline styles where Tailwind `dark:` can't reach gradients

### Mobile Layout
- Sentence filter button at very top (above safe area), logo/auth row below it
- Pull-to-collapse gesture on bottom sheet
- Zoom controls (Plus/Minus) and locate button stacked above bottom sheet
- Back button in sheet header stops drag propagation — prevents accidental sheet cycling

### Navigation & State
- Scroll position saved/restored when navigating list ↔ detail
- Sheet snap position saved/restored when returning from detail
- Detail header row blocks all touch drag events (not just back button)
- Preferences panel closing while at peek auto-expands to middle

### Visual Polish
- Photo card color extraction (3-bit quantisation, warm bias)
- Image load error fallback to text card
- Bookmark + visited buttons moved below title in detail panel
- Fit blurb hidden from list cards (detail panel only)
- Leaflet zoom controls replaced with React buttons (escape z-index isolation)

### Bug Fixes
- Sign-in modal transparency fixed (removed `opacity-70` wrapper inheritance)
- Desktop controls positioned left of sidebar
- iOS safe area handled with `env(safe-area-inset-top)`

## Testing
- All 9 Vitest integration tests pass
- ESLint clean